### PR TITLE
Parameters to Model.fetch() ajax requests

### DIFF
--- a/lib/spine.model.ajax.js
+++ b/lib/spine.model.ajax.js
@@ -18,7 +18,7 @@ var urlError = function() {
   throw new Error("A 'url' property or function must be specified");
 };
 
-var ajaxSync = function(method, record){
+var ajaxSync = function(method, record, fetchParams){
   if (Model._noSync) return;
   
   var params = {
@@ -48,10 +48,19 @@ var ajaxSync = function(method, record){
     params.data = JSON.stringify(data);
   }
     
-  if (method == "read")
+  if (method == "read") {
     params.success = function(data){
       (record.refresh || record.load).call(record, data);
     };
+
+		if (fetchParams) {
+			if ($.isPlainObject(fetchParams)) {
+				params.url = params.url + '?' + $.param( fetchParams );
+			} else {
+				params.url = params.url + fetchParams;
+			}
+		}
+	}
 
   params.error = function(xhr, s, e){
     record.trigger("ajaxError", xhr, s, e);
@@ -63,8 +72,8 @@ var ajaxSync = function(method, record){
 Model.Ajax = {
   extended: function(){    
     this.sync(ajaxSync);
-    this.fetch(this.proxy(function(){
-      ajaxSync("read", this);
+    this.fetch(this.proxy(function(fetchParams){
+      ajaxSync("read", this, fetchParams);
     }));
   }
 };

--- a/spine.js
+++ b/spine.js
@@ -307,8 +307,8 @@
       this.bind("change", callback);
     },
 
-    fetch: function(callback){
-      callback ? this.bind("fetch", callback) : this.trigger("fetch");
+    fetch: function(callbackOrParams){
+      $.isFunction(callbackOrParams) ? this.bind("fetch", callbackOrParams) : this.trigger("fetch", callbackOrParams);
     },
 
     toJSON: function(){


### PR DESCRIPTION
Hi Maccman,

With the Ajax Adapter, `Model.fetch()` doesn't allow to pass parameters to the requests. 
It makes (server side) pages/sorting/limit/search on fetched Models hard to implement.

Please, check my commit.

``` javascript
  Model.fetch({
    page:  1,
    order: 'field',
    dir:   'asc',
    limit: 100
  });
```

Params above add `?page=1&order=field&dir=asc&limit=100` to `Model.url`
To respect the RESTFull orientation of Spine, you can simply add whatever string you want:

``` javascript
    Model.fetch('/page/1/field/asc/100');
```

Jay
