### PR TITLE
Fetch with params fix and allow setting expected prefix in response

### DIFF
--- a/lib/spine.model.ajax.js
+++ b/lib/spine.model.ajax.js
@@ -18,15 +18,15 @@ var urlError = function() {
   throw new Error("A 'url' property or function must be specified");
 };
 
-var ajaxSync = function(record, method, params){
+var ajaxSync = function(record, method, data){
   if (Model._noSync) return;
   
-  params = $.extend({
+  var params = {
     type:          methodMap[method],
     contentType:  "application/json",
     dataType:     "json",
-    processData:  false
-  }, params || {});
+    data:         data,
+  };
     
   if (method == "create" && record.model)
     params.url = getUrl(record.parent);
@@ -47,6 +47,7 @@ var ajaxSync = function(record, method, params){
     }
     data = $.extend(data, params.data);
     params.data = JSON.stringify(data);
+    params.processData = false;
   }
   
   if (method == "read" && !params.success)

--- a/spine.js
+++ b/spine.js
@@ -213,6 +213,9 @@
     },
 
     refresh: function(values){
+      if(Model.ajaxPrefix && this.prefix) {
+        values = values[this.prefix];
+      }
       values = this.fromJSON(values);
       this.records = {};
 
@@ -299,8 +302,8 @@
       this.bind("change", callback);
     },
 
-    fetch: function(callback){
-      callback ? this.bind("fetch", callback) : this.trigger("fetch");
+    fetch: function(callbackOrParams){
+      typeof(callbackOrParams) == 'function' ? this.bind("fetch", callbackOrParams) : this.trigger("fetch", callbackOrParams);
     },
 
     toJSON: function(){


### PR DESCRIPTION
Can now specify what the response prefix will be when
making Ajax requests

Fixed adding params to fetches
