### PR TITLE
Cs branch Updated spine lib to export on module.exports and bug in exports detection

### DIFF
--- a/lib/spine.js
+++ b/lib/spine.js
@@ -582,11 +582,7 @@
       return v.toString(16);
     }).toUpperCase();
   };
-  if (typeof exports === !"undefined") {
-    Spine = exports;
-  } else {
-    Spine = this.Spine = {};
-  }
+  Spine = this.Spine = {};
   Spine.version = "2.0.0";
   Spine.isArray = isArray;
   Spine.$ = $;
@@ -619,4 +615,7 @@
     return new this(a1, a2, a3, a4, a5);
   };
   Spine.Class = Module;
+  if (typeof exports !== "undefined" && exports !== null) {
+    module.exports = Spine;
+  }
 }).call(this);

--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -394,10 +394,8 @@ guid = ->
 
 # Globals
 
-if typeof exports is not "undefined"
-  Spine = exports
-else
-  Spine = @Spine = {}
+
+Spine = @Spine = {}
   
 Spine.version    = "2.0.0"
 Spine.isArray    = isArray
@@ -423,3 +421,5 @@ Module.init = Controller.init = Model.init = (a1, a2, a3, a4, a5) ->
   new this(a1, a2, a3, a4, a5)
 
 Spine.Class = Module
+
+module.exports = Spine if exports?


### PR DESCRIPTION
cs branch looks pretty under dev but here's a few lines of fixes re exports

The old 'if exports is not "undefined"' check -always- evaluates to false since coffeescript compiles it to:

```
if (typeof exports === !"undefined") 
```

where (!"any string") always === false. 

Could use isnt keyword

```
if exports isnt "undefined"
```

 but existential operator arguably more semantic since we are checking existence:
    if exports?

Also using module.exports means you don't have to

```
var spine = require('spine').Spine
```

(which I seemed to need to do to get the spine object)
instead can just

   var spine = require('spine'); 
