### PR TITLE
Controller destroy function + trigger

### DIFF
--- a/lib/spine.js
+++ b/lib/spine.js
@@ -501,6 +501,9 @@
         this.refreshElements();
       }
     }
+    Controller.prototype.destroy = function() {
+      return this.trigger("destroy");
+    };
     Controller.prototype.$ = function(selector) {
       return $(selector, this.el);
     };
@@ -513,7 +516,11 @@
         match = key.match(this.eventSplitter);
         eventName = match[1];
         selector = match[2];
-        _results.push(selector === '' ? this.el.bind(eventName, method) : this.el.delegate(selector, eventName, method));
+        _results.push(selector === '' ? (this.el.bind(eventName, method), this.bind("destroy", function() {
+          return this.el.unbind(eventName, method);
+        })) : (this.el.delegate(selector, eventName, method), this.bind("destroy", function() {
+          return this.el.undelegate(selector, eventName, method);
+        })));
       }
       return _results;
     };

--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -337,6 +337,9 @@ class Controller extends Module
 
     @delegateEvents() if @events
     @refreshElements() if @elements
+     
+  destroy: ->
+    @trigger "destroy"
       
   $: (selector) -> $(selector, @el)
       
@@ -351,8 +354,12 @@ class Controller extends Module
 
       if selector is ''
         @el.bind(eventName, method)
+        @bind "destroy", ->
+          @el.unbind(eventName, method)
       else
         @el.delegate(selector, eventName, method)
+        @bind "destroy", ->
+          @el.undelegate(selector, eventName, method)
   
   refreshElements: ->
     for key, value of @elements


### PR DESCRIPTION
Allows controllers to clean up events when .destroy is called. This helps prevent leaks as controllers are created/destroyed during an application's life.

I'm also using it to remove any bindings to other Spine objects, I'll put that work in another branch soon.
