### PR TITLE
Added dataType (json) to Ajax Base class to fix issues with Rails

### DIFF
--- a/src/spine.ajax.coffee
+++ b/src/spine.ajax.coffee
@@ -39,6 +39,7 @@ Ajax =
 class Base
   defaults:
     contentType: "application/json"
+    dataType: "json"
     processData: false
   
   send: (params, defaults) ->


### PR DESCRIPTION
The CS branch's Ajax adapter was missing the `dataType` attribute, which was causing issues with Rails (which was sending back HTML instead of JSON).
