### PR TITLE
Fix errorResponse() trigger in Ajax Collection Class for ajaxError

### DIFF
--- a/src/ajax.coffee
+++ b/src/ajax.coffee
@@ -69,7 +69,7 @@ class Collection extends Base
     success = params.success
     
     (data, status, xhr) =>
-      model.trigger("ajaxSuccess", null, status, xhr)
+      @model.trigger("ajaxSuccess", null, status, xhr)
       success?(@model.fromJSON(data))
 
   errorResponse: (params = {}) =>


### PR DESCRIPTION
should be @model.trigger not @record.trigger because it is in the Collection Class. 

it was calling @record.trigger and it does not exist in the Collection Class. It is supposed to be @model.trigger
