### PR TITLE
Added an alternate version of handling init directly in module

### DIFF
--- a/lib/spine.js
+++ b/lib/spine.js
@@ -88,7 +88,11 @@
   };
   moduleKeywords = ["included", "extended"];
   Module = (function() {
-    function Module() {}
+    function Module() {
+      if (this.init) {
+        this.init.apply(this, arguments);
+      }
+    }
     Module.include = function(obj) {
       var included, key, value;
       if (!obj) {
@@ -524,6 +528,7 @@
       if (this.elements) {
         this.refreshElements();
       }
+      Controller.__super__.constructor.apply(this, arguments);
     }
     Controller.prototype.destroy = function() {
       return this.trigger("destroy");
@@ -680,12 +685,5 @@
     return new this(a1, a2, a3, a4, a5);
   };
   Spine.App = new Controller;
-  Spine.Class = (function() {
-    __extends(Class, Module);
-    Class.prototype.init = function() {};
-    function Class() {
-      this.init.apply(this, arguments);
-    }
-    return Class;
-  })();
+  Spine.Class = Module;
 }).call(this);

--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -53,6 +53,9 @@ Log =
 moduleKeywords = ["included", "extended"]
 
 class Module
+  constructor: ->
+    @init(arguments...) if @init
+
   @include: (obj) ->
     throw("include(obj) requires obj") unless obj
     for key, value of obj when key not in moduleKeywords
@@ -353,6 +356,7 @@ class Controller extends Module
 
     @delegateEvents() if @events
     @refreshElements() if @elements
+    super
      
   destroy: ->
     @trigger "destroy"
@@ -464,8 +468,4 @@ Module.init = Controller.init = Model.init = (a1, a2, a3, a4, a5) ->
   new this(a1, a2, a3, a4, a5)
   
 Spine.App = new Controller
-class Spine.Class extends Module
-  init: ->
-  
-  constructor: ->
-    @init(arguments...)
+Spine.Class = Module


### PR DESCRIPTION
Based on our conversion on the spine list here is an alternate version of the init method. I put together some performance tests so hopefully the CoffeeScript users wouldn't have an init performance hit if they aren't using it.

You can see the perf tests here.

http://jsperf.com/coffeescript-compiled-impact-of-empty-method-call/2

Essentially it doesn't call init unless it exists.. which it doesn't by default.

Nathan
