### PR TITLE
Add item parameter to forItem in tmpl.coffee

### DIFF
--- a/src/tmpl.coffee
+++ b/src/tmpl.coffee
@@ -6,7 +6,8 @@ $.fn.item = ->
   item = $(@).tmplItem().data
   item.reload?()
 
-$.fn.forItem = ->
+$.fn.forItem = (item) ->
   @filter ->
     compare = $(@).item()
     return item.eql?(compare) or item is compare
+


### PR DESCRIPTION
It looks like the (item) parameter didn't make the transition to coffeescript. Without the paramater I get an 'item not defined' exception when using the .forItem method.
