### PR TITLE
Pass params in Collection.fetch

### DIFF
--- a/lib/ajax.js
+++ b/lib/ajax.js
@@ -79,8 +79,8 @@
         url: Ajax.getURL(this.model)
       }).success(this.recordsResponse).error(this.errorResponse);
     };
-    Collection.prototype.fetch = function() {
-      return this.findAll().success(__bind(function(records) {
+    Collection.prototype.fetch = function(params) {
+      return this.findAll(params).success(__bind(function(records) {
         return this.model.refresh(records);
       }, this));
     };

--- a/src/ajax.coffee
+++ b/src/ajax.coffee
@@ -56,8 +56,8 @@ class Collection extends Base
     ).success(@recordsResponse)
      .error(@errorResponse)
     
-  fetch: ->
-    @findAll().success (records) =>
+  fetch: (params) ->
+    @findAll(params).success (records) =>
       @model.refresh(records)
     
   recordsResponse: (data, status, xhr) =>


### PR DESCRIPTION
It looks like this had been added in the js version, but may have been
overlooked in the cs port.  Just allows jquery ajax parameters to be
passed into fetch() which can be useful for paging, etc.

As a side note, I was trying to add a spec for this, but it looks like the ajax specs are busted?  Probably me doing something wrong, but if you could point me in the right direction in running these, I could add the tests as well.
