### PR TITLE
Set correct default eventSplitter

### DIFF
--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -345,7 +345,7 @@ class Controller extends Module
   @include Events
   @include Log
   
-  eventSplitter: /^(\w+)\s*(.*)$/
+  eventSplitter: /^(\S+)\s*(.*)$/
   tag: 'div'
   
   constructor: (options) ->


### PR DESCRIPTION
I had some problems with current eventSpitter, for example with namespaced events:

``` js
'click.test #some_link'.match(/^(\w+)\s*(.*)$/)

// => ["click.test #some_link", "click", ".test #some_elm"]
```

and with jQuery UJS events (https://github.com/rails/jquery-ujs/wiki/ajax):

``` js
'ajax:success #some_form'.match(/^(\w+)\s*(.*)$/)

// => ["ajax:success #some_form", "ajax", ":success #some_elm"]
```

Correct eventSplitter expression is `/^(\S+)\s*(.*)$/`
