### PR TITLE
Fix @refresh() when it's called with something other than an array

### DIFF
--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -115,8 +115,11 @@ class Model extends Module
 
   @refresh: (values, options = {}) ->
     @records = {} if options.clear
-
-    for record in @fromJSON(values) 
+    records = @fromJSON(values)
+    
+    records = [records] unless isArray(records)
+    
+    for record in records
       record.newRecord    = false
       record.id           or= guid()
       @records[record.id] = record


### PR DESCRIPTION
Using @fetch() to get a single record as in 1f954333b34 is incompatible with Model.refresh(), which expects an array of objects. This converts the first argument to @refresh() to an array unless it already is one.
