### PR TITLE
@add() method and "add" event

### DIFF
--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -119,13 +119,17 @@ class Model extends Module
     
     records = [records] unless isArray(records)
     
-    for record in records
-      record.newRecord    = false
-      record.id           or= guid()
-      @records[record.id] = record
+    @add(record) for record in records
 
     @trigger('refresh', not options.clear and records)
     @
+
+  @add: (record) ->
+    record.newRecord    = false
+    record.id           or= guid()
+    @records[record.id] = record
+    @trigger('add', record)
+    @    
 
   @select: (callback) ->
     result = (record for id, record of @records when callback(record))


### PR DESCRIPTION
This is what I was referring to: wrap up the record-adding logic into a public method which fires "add" with each record added, and call it from refresh() with each record for the case when the entire collection is refreshed. 

This theoretically gives you a way to add/reload a single record without needing to call save(), and adds a separate event to listen to when a single record is fetch()'ed.

I'm thinking this might address @facto's need to refresh a single record with the full data, but without sharing the "refresh" event with list views, etc.

I left out calling fromJSON() inside, which would add to its utility, for performance concerns. After profiling it, there's actually little difference. I also left out any change to Spine.Ajax, but the intention here is that calling fetch() for one record would call add() instead of refresh().
