### PR TITLE
Select tab when a controller becomes active

### DIFF
--- a/src/tabs.coffee
+++ b/src/tabs.coffee
@@ -30,5 +30,7 @@ class Spine.Tabs extends Spine.Controller
   connect: (tabName, controller) ->
     @bind 'change', (name) ->
       controller.active() if name == tabName
+	controller.bind "active", () =>
+	      @change tabName
       
 module?.exports = Spine.Tabs


### PR DESCRIPTION
Automatically select the tab associated with a controller when it becomes active. Without this, only clicks will change the "active" state of the tab, so programmatically changing the active controller won't select the right tab. This is useful when, say, you load the app at a routed url.
