### PR TITLE
Expose Ajax.defaults properly

### DIFF
--- a/lib/ajax.js
+++ b/lib/ajax.js
@@ -266,7 +266,7 @@
     }
   };
 
-  Ajax.defaults = Base.defaults;
+  Ajax.defaults = Base.prototype.defaults;
 
   Spine.Ajax = Ajax;
 

--- a/src/ajax.coffee
+++ b/src/ajax.coffee
@@ -188,6 +188,6 @@ Model.Ajax.Methods =
     @include Include
     
 # Globals
-Ajax.defaults   = Base.defaults
+Ajax.defaults   = Base::defaults
 Spine.Ajax      = Ajax
 module?.exports = Ajax

--- a/test/specs/ajax.js
+++ b/test/specs/ajax.js
@@ -137,4 +137,8 @@ describe("Ajax", function(){
       jqXHR.reject();
       expect(spy).toHaveBeenCalled();
     });
+
+    it("should expose the defaults object", function(){
+      expect(Spine.Ajax.defaults).toBeDefined();
+    });
 });


### PR DESCRIPTION
The `defaults` are on `Base.prototype`, this fix exposes that property
for manipulation.
