### PR TITLE
Add correct pluralization for it to work with rails styles pluralization

### DIFF
--- a/lib/ajax.js
+++ b/lib/ajax.js
@@ -1,13 +1,18 @@
 (function() {
   var $, Ajax, Base, Collection, Extend, Include, Model, Singleton;
-  var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; }, __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; };
-
-  if (typeof Spine === "undefined" || Spine === null) Spine = require('spine');
-
+  var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; }, __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) {
+    for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; }
+    function ctor() { this.constructor = child; }
+    ctor.prototype = parent.prototype;
+    child.prototype = new ctor;
+    child.__super__ = parent.prototype;
+    return child;
+  };
+  if (typeof Spine === "undefined" || Spine === null) {
+    Spine = require('spine');
+  }
   $ = Spine.$;
-
   Model = Spine.Model;
-
   Ajax = {
     getURL: function(object) {
       return object && (typeof object.url === "function" ? object.url() : void 0) || object.url;
@@ -30,13 +35,14 @@
       }
     },
     request: function(callback) {
-      var _this = this;
-      return (callback()).complete(function() {
-        return _this.requestNext();
-      });
+      return (callback()).complete(__bind(function() {
+        return this.requestNext();
+      }, this));
     },
     queue: function(callback) {
-      if (!this.enabled) return;
+      if (!this.enabled) {
+        return;
+      }
       if (this.pending) {
         this.requests.push(callback);
       } else {
@@ -46,11 +52,8 @@
       return callback;
     }
   };
-
   Base = (function() {
-
     function Base() {}
-
     Base.prototype.defaults = {
       contentType: 'application/json',
       dataType: 'json',
@@ -59,29 +62,21 @@
         'X-Requested-With': 'XMLHttpRequest'
       }
     };
-
     Base.prototype.ajax = function(params, defaults) {
       return $.ajax($.extend({}, this.defaults, defaults, params));
     };
-
     Base.prototype.queue = function(callback) {
       return Ajax.queue(callback);
     };
-
     return Base;
-
   })();
-
   Collection = (function() {
-
     __extends(Collection, Base);
-
     function Collection(model) {
       this.model = model;
       this.errorResponse = __bind(this.errorResponse, this);
       this.recordsResponse = __bind(this.recordsResponse, this);
     }
-
     Collection.prototype.find = function(id, params) {
       var record;
       record = new this.model({
@@ -92,134 +87,114 @@
         url: Ajax.getURL(record)
       }).success(this.recordsResponse).error(this.errorResponse);
     };
-
     Collection.prototype.all = function(params) {
       return this.ajax(params, {
         type: 'GET',
         url: Ajax.getURL(this.model)
       }).success(this.recordsResponse).error(this.errorResponse);
     };
-
     Collection.prototype.fetch = function(params) {
       var id;
-      var _this = this;
-      if (params == null) params = {};
+      if (params == null) {
+        params = {};
+      }
       if (id = params.id) {
         delete params.id;
-        return this.find(id, params).success(function(record) {
-          return _this.model.refresh(record);
-        });
+        return this.find(id, params).success(__bind(function(record) {
+          return this.model.refresh(record);
+        }, this));
       } else {
-        return this.all(params).success(function(records) {
-          return _this.model.refresh(records);
-        });
+        return this.all(params).success(__bind(function(records) {
+          return this.model.refresh(records);
+        }, this));
       }
     };
-
     Collection.prototype.recordsResponse = function(data, status, xhr) {
       return this.model.trigger('ajaxSuccess', null, status, xhr);
     };
-
     Collection.prototype.errorResponse = function(xhr, statusText, error) {
       return this.model.trigger('ajaxError', null, xhr, statusText, error);
     };
-
     return Collection;
-
   })();
-
   Singleton = (function() {
-
     __extends(Singleton, Base);
-
     function Singleton(record) {
       this.record = record;
       this.errorResponse = __bind(this.errorResponse, this);
       this.recordResponse = __bind(this.recordResponse, this);
       this.model = this.record.constructor;
     }
-
     Singleton.prototype.reload = function(params, options) {
-      var _this = this;
-      return this.queue(function() {
-        return _this.ajax(params, {
+      return this.queue(__bind(function() {
+        return this.ajax(params, {
           type: 'GET',
-          url: Ajax.getURL(_this.record)
-        }).success(_this.recordResponse(options)).error(_this.errorResponse(options));
-      });
+          url: Ajax.getURL(this.record)
+        }).success(this.recordResponse(options)).error(this.errorResponse(options));
+      }, this));
     };
-
     Singleton.prototype.create = function(params, options) {
-      var _this = this;
-      return this.queue(function() {
-        return _this.ajax(params, {
+      return this.queue(__bind(function() {
+        return this.ajax(params, {
           type: 'POST',
-          data: JSON.stringify(_this.record),
-          url: Ajax.getURL(_this.model)
-        }).success(_this.recordResponse(options)).error(_this.errorResponse(options));
-      });
+          data: JSON.stringify(this.record),
+          url: Ajax.getURL(this.model)
+        }).success(this.recordResponse(options)).error(this.errorResponse(options));
+      }, this));
     };
-
     Singleton.prototype.update = function(params, options) {
-      var _this = this;
-      return this.queue(function() {
-        return _this.ajax(params, {
+      return this.queue(__bind(function() {
+        return this.ajax(params, {
           type: 'PUT',
-          data: JSON.stringify(_this.record),
-          url: Ajax.getURL(_this.record)
-        }).success(_this.recordResponse(options)).error(_this.errorResponse(options));
-      });
+          data: JSON.stringify(this.record),
+          url: Ajax.getURL(this.record)
+        }).success(this.recordResponse(options)).error(this.errorResponse(options));
+      }, this));
     };
-
     Singleton.prototype.destroy = function(params, options) {
-      var _this = this;
-      return this.queue(function() {
-        return _this.ajax(params, {
+      return this.queue(__bind(function() {
+        return this.ajax(params, {
           type: 'DELETE',
-          url: Ajax.getURL(_this.record)
-        }).success(_this.recordResponse(options)).error(_this.errorResponse(options));
-      });
+          url: Ajax.getURL(this.record)
+        }).success(this.recordResponse(options)).error(this.errorResponse(options));
+      }, this));
     };
-
     Singleton.prototype.recordResponse = function(options) {
-      var _this = this;
-      if (options == null) options = {};
-      return function(data, status, xhr) {
+      if (options == null) {
+        options = {};
+      }
+      return __bind(function(data, status, xhr) {
         if (Spine.isBlank(data)) {
           data = false;
         } else {
-          data = _this.model.fromJSON(data);
+          data = this.model.fromJSON(data);
         }
-        return Ajax.disable(function() {
+        return Ajax.disable(__bind(function() {
           var _ref;
           if (data) {
-            if (data.id && _this.record.id !== data.id) {
-              _this.record.changeID(data.id);
+            if (data.id && this.record.id !== data.id) {
+              this.record.changeID(data.id);
             }
-            _this.record.updateAttributes(data.attributes());
+            this.record.updateAttributes(data.attributes());
           }
-          _this.record.trigger('ajaxSuccess', data, status, xhr);
-          return (_ref = options.success) != null ? _ref.apply(_this.record) : void 0;
-        });
-      };
+          this.record.trigger('ajaxSuccess', data, status, xhr);
+          return (_ref = options.success) != null ? _ref.apply(this.record) : void 0;
+        }, this));
+      }, this);
     };
-
     Singleton.prototype.errorResponse = function(options) {
-      var _this = this;
-      if (options == null) options = {};
-      return function(xhr, statusText, error) {
+      if (options == null) {
+        options = {};
+      }
+      return __bind(function(xhr, statusText, error) {
         var _ref;
-        _this.record.trigger('ajaxError', xhr, statusText, error);
-        return (_ref = options.error) != null ? _ref.apply(_this.record) : void 0;
-      };
+        this.record.trigger('ajaxError', xhr, statusText, error);
+        return (_ref = options.error) != null ? _ref.apply(this.record) : void 0;
+      }, this);
     };
-
     return Singleton;
-
   })();
-
   Model.host = '';
-
   Include = {
     ajax: function() {
       return new Singleton(this);
@@ -227,21 +202,21 @@
     url: function() {
       var base;
       base = Ajax.getURL(this.constructor);
-      if (base.charAt(base.length - 1) !== '/') base += '/';
+      if (base.charAt(base.length - 1) !== '/') {
+        base += '/';
+      }
       base += encodeURIComponent(this.id);
       return base;
     }
   };
-
   Extend = {
     ajax: function() {
       return new Collection(this);
     },
     url: function() {
-      return "" + Model.host + "/" + (this.className.toLowerCase()) + "s";
+      return "" + Model.host + "/" + (this.className.toLowerCase().pluralize());
     }
   };
-
   Model.Ajax = {
     extended: function() {
       this.fetch(this.ajaxFetch);
@@ -254,22 +229,21 @@
       return (_ref = this.ajax()).fetch.apply(_ref, arguments);
     },
     ajaxChange: function(record, type, options) {
-      if (options == null) options = {};
+      if (options == null) {
+        options = {};
+      }
       return record.ajax()[type](options.ajax, options);
     }
   };
-
   Model.Ajax.Methods = {
     extended: function() {
       this.extend(Extend);
       return this.include(Include);
     }
   };
-
   Ajax.defaults = Base.prototype.defaults;
-
   Spine.Ajax = Ajax;
-
-  if (typeof module !== "undefined" && module !== null) module.exports = Ajax;
-
+  if (typeof module !== "undefined" && module !== null) {
+    module.exports = Ajax;
+  }
 }).call(this);

--- a/lib/inflections.js
+++ b/lib/inflections.js
@@ -1,0 +1,232 @@
+(function() {
+  var $, InflectionJS;
+  if (typeof Spine === "undefined" || Spine === null) {
+    Spine = require('spine');
+  }
+  $ = Spine.$;
+  if (window && !window.InflectionJS) {
+    window.InflectionJS = null;
+  }
+  InflectionJS = {
+    uncountable_words: ["equipment", "information", "rice", "money", "species", "series", "fish", "sheep", "moose", "deer", "news"],
+    plural_rules: [[new RegExp("(m)an$", "gi"), "$1en"], [new RegExp("(pe)rson$", "gi"), "$1ople"], [new RegExp("(child)$", "gi"), "$1ren"], [new RegExp("^(ox)$", "gi"), "$1en"], [new RegExp("(ax|test)is$", "gi"), "$1es"], [new RegExp("(octop|vir)us$", "gi"), "$1i"], [new RegExp("(alias|status)$", "gi"), "$1es"], [new RegExp("(bu)s$", "gi"), "$1ses"], [new RegExp("(buffal|tomat|potat)o$", "gi"), "$1oes"], [new RegExp("([ti])um$", "gi"), "$1a"], [new RegExp("sis$", "gi"), "ses"], [new RegExp("(?:([^f])fe|([lr])f)$", "gi"), "$1$2ves"], [new RegExp("(hive)$", "gi"), "$1s"], [new RegExp("([^aeiouy]|qu)y$", "gi"), "$1ies"], [new RegExp("(x|ch|ss|sh)$", "gi"), "$1es"], [new RegExp("(matr|vert|ind)ix|ex$", "gi"), "$1ices"], [new RegExp("([m|l])ouse$", "gi"), "$1ice"], [new RegExp("(quiz)$", "gi"), "$1zes"], [new RegExp("s$", "gi"), "s"], [new RegExp("$", "gi"), "s"]],
+    singular_rules: [[new RegExp("(m)en$", "gi"), "$1an"], [new RegExp("(pe)ople$", "gi"), "$1rson"], [new RegExp("(child)ren$", "gi"), "$1"], [new RegExp("([ti])a$", "gi"), "$1um"], [new RegExp("((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)ses$", "gi"), "$1$2sis"], [new RegExp("(hive)s$", "gi"), "$1"], [new RegExp("(tive)s$", "gi"), "$1"], [new RegExp("(curve)s$", "gi"), "$1"], [new RegExp("([lr])ves$", "gi"), "$1f"], [new RegExp("([^fo])ves$", "gi"), "$1fe"], [new RegExp("([^aeiouy]|qu)ies$", "gi"), "$1y"], [new RegExp("(s)eries$", "gi"), "$1eries"], [new RegExp("(m)ovies$", "gi"), "$1ovie"], [new RegExp("(x|ch|ss|sh)es$", "gi"), "$1"], [new RegExp("([m|l])ice$", "gi"), "$1ouse"], [new RegExp("(bus)es$", "gi"), "$1"], [new RegExp("(o)es$", "gi"), "$1"], [new RegExp("(shoe)s$", "gi"), "$1"], [new RegExp("(cris|ax|test)es$", "gi"), "$1is"], [new RegExp("(octop|vir)i$", "gi"), "$1us"], [new RegExp("(alias|status)es$", "gi"), "$1"], [new RegExp("^(ox)en", "gi"), "$1"], [new RegExp("(vert|ind)ices$", "gi"), "$1ex"], [new RegExp("(matr)ices$", "gi"), "$1ix"], [new RegExp("(quiz)zes$", "gi"), "$1"], [new RegExp("s$", "gi"), ""]],
+    non_titlecased_words: ["and", "or", "nor", "a", "an", "the", "so", "but", "to", "of", "at", "by", "from", "into", "on", "onto", "off", "out", "in", "over", "with", "for"],
+    id_suffix: new RegExp("(_ids|_id)$", "g"),
+    underbar: new RegExp("_", "g"),
+    space_or_underbar: new RegExp("[ _]", "g"),
+    uppercase: new RegExp("([A-Z])", "g"),
+    underbar_prefix: new RegExp("^_"),
+    apply_rules: function(str, rules, skip, override) {
+      var ignore, x;
+      if (override) {
+        str = override;
+      } else {
+        ignore = skip.indexOf(str.toLowerCase()) > -1;
+        if (!ignore) {
+          x = 0;
+          while (x < rules.length) {
+            if (str.match(rules[x][0])) {
+              str = str.replace(rules[x][0], rules[x][1]);
+              break;
+            }
+            x++;
+          }
+        }
+      }
+      return str;
+    }
+  };
+  if (!Array.prototype.indexOf) {
+    Array.prototype.indexOf = function(item, fromIndex, compareFunc) {
+      var i, index;
+      if (!fromIndex) {
+        fromIndex = -1;
+      }
+      index = -1;
+      i = fromIndex;
+      while (i < this.length) {
+        if (this[i] === item || compareFunc && compareFunc(this[i], item)) {
+          index = i;
+          break;
+        }
+        i++;
+      }
+      return index;
+    };
+  }
+  if (!String.prototype._uncountable_words) {
+    String.prototype._uncountable_words = InflectionJS.uncountable_words;
+  }
+  if (!String.prototype._plural_rules) {
+    String.prototype._plural_rules = InflectionJS.plural_rules;
+  }
+  if (!String.prototype._singular_rules) {
+    String.prototype._singular_rules = InflectionJS.singular_rules;
+  }
+  if (!String.prototype._non_titlecased_words) {
+    String.prototype._non_titlecased_words = InflectionJS.non_titlecased_words;
+  }
+  if (!String.prototype.pluralize) {
+    String.prototype.pluralize = function(plural) {
+      return InflectionJS.apply_rules(this, this._plural_rules, this._uncountable_words, plural);
+    };
+  }
+  if (!String.prototype.singularize) {
+    String.prototype.singularize = function(singular) {
+      return InflectionJS.apply_rules(this, this._singular_rules, this._uncountable_words, singular);
+    };
+  }
+  if (!String.prototype.camelize) {
+    String.prototype.camelize = function(lowFirstLetter) {
+      var i, initX, str, str_arr, str_path, x;
+      str = this.toLowerCase();
+      str_path = str.split("/");
+      i = 0;
+      while (i < str_path.length) {
+        str_arr = str_path[i].split("_");
+        initX = (lowFirstLetter && i + 1 === str_path.length ? 1. : 0.);
+        x = initX;
+        while (x < str_arr.length) {
+          str_arr[x] = str_arr[x].charAt(0).toUpperCase() + str_arr[x].substring(1);
+          x++;
+        }
+        str_path[i] = str_arr.join("");
+        i++;
+      }
+      str = str_path.join("::");
+      return str;
+    };
+  }
+  if (!String.prototype.underscore) {
+    String.prototype.underscore = function() {
+      var i, str, str_path;
+      str = this;
+      str_path = str.split("::");
+      i = 0;
+      while (i < str_path.length) {
+        str_path[i] = str_path[i].replace(InflectionJS.uppercase, "_$1");
+        str_path[i] = str_path[i].replace(InflectionJS.underbar_prefix, "");
+        i++;
+      }
+      str = str_path.join("/").toLowerCase();
+      return str;
+    };
+  }
+  if (!String.prototype.humanize) {
+    String.prototype.humanize = function(lowFirstLetter) {
+      var str;
+      str = this.toLowerCase();
+      str = str.replace(InflectionJS.id_suffix, "");
+      str = str.replace(InflectionJS.underbar, " ");
+      if (!lowFirstLetter) {
+        str = str.capitalize();
+      }
+      return str;
+    };
+  }
+  if (!String.prototype.capitalize) {
+    String.prototype.capitalize = function() {
+      var str;
+      str = this.toLowerCase();
+      str = str.substring(0, 1).toUpperCase() + str.substring(1);
+      return str;
+    };
+  }
+  if (!String.prototype.dasherize) {
+    String.prototype.dasherize = function() {
+      var str;
+      str = this;
+      str = str.replace(InflectionJS.space_or_underbar, "-");
+      return str;
+    };
+  }
+  if (!String.prototype.titleize) {
+    String.prototype.titleize = function() {
+      var d, i, str, str_arr, x;
+      str = this.toLowerCase();
+      str = str.replace(InflectionJS.underbar, " ");
+      str_arr = str.split(" ");
+      x = 0;
+      while (x < str_arr.length) {
+        d = str_arr[x].split("-");
+        i = 0;
+        while (i < d.length) {
+          if (this._non_titlecased_words.indexOf(d[i].toLowerCase()) < 0) {
+            d[i] = d[i].capitalize();
+          }
+          i++;
+        }
+        str_arr[x] = d.join("-");
+        x++;
+      }
+      str = str_arr.join(" ");
+      str = str.substring(0, 1).toUpperCase() + str.substring(1);
+      return str;
+    };
+  }
+  if (!String.prototype.demodulize) {
+    String.prototype.demodulize = function() {
+      var str, str_arr;
+      str = this;
+      str_arr = str.split("::");
+      str = str_arr[str_arr.length - 1];
+      return str;
+    };
+  }
+  if (!String.prototype.tableize) {
+    String.prototype.tableize = function() {
+      var str;
+      str = this;
+      str = str.underscore().pluralize();
+      return str;
+    };
+  }
+  if (!String.prototype.classify) {
+    String.prototype.classify = function() {
+      var str;
+      str = this;
+      str = str.camelize().singularize();
+      return str;
+    };
+  }
+  if (!String.prototype.foreign_key) {
+    String.prototype.foreign_key = function(dropIdUbar) {
+      var str;
+      str = this;
+      str = str.demodulize().underscore() + (dropIdUbar ? "" : "_") + "id";
+      return str;
+    };
+  }
+  if (!String.prototype.ordinalize) {
+    String.prototype.ordinalize = function() {
+      var i, ld, ltd, str, str_arr, suf, x;
+      str = this;
+      str_arr = str.split(" ");
+      x = 0;
+      while (x < str_arr.length) {
+        i = parseInt(str_arr[x]);
+        if (i === NaN) {
+          ltd = str_arr[x].substring(str_arr[x].length - 2);
+          ld = str_arr[x].substring(str_arr[x].length - 1);
+          suf = "th";
+          if (ltd !== "11" && ltd !== "12" && ltd !== "13") {
+            if (ld === "1") {
+              suf = "st";
+            } else if (ld === "2") {
+              suf = "nd";
+            } else {
+              if (ld === "3") {
+                suf = "rd";
+              }
+            }
+          }
+          str_arr[x] += suf;
+        }
+        x++;
+      }
+      str = str_arr.join(" ");
+      return str;
+    };
+  }
+}).call(this);

--- a/lib/list.js
+++ b/lib/list.js
@@ -1,30 +1,30 @@
 (function() {
   var $;
-  var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; }, __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; };
-
-  if (typeof Spine === "undefined" || Spine === null) Spine = require('spine');
-
+  var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; }, __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) {
+    for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; }
+    function ctor() { this.constructor = child; }
+    ctor.prototype = parent.prototype;
+    child.prototype = new ctor;
+    child.__super__ = parent.prototype;
+    return child;
+  };
+  if (typeof Spine === "undefined" || Spine === null) {
+    Spine = require('spine');
+  }
   $ = Spine.$;
-
   Spine.List = (function() {
-
     __extends(List, Spine.Controller);
-
     List.prototype.events = {
       'click .item': 'click'
     };
-
     List.prototype.selectFirst = false;
-
     function List() {
       this.change = __bind(this.change, this);      List.__super__.constructor.apply(this, arguments);
       this.bind('change', this.change);
     }
-
     List.prototype.template = function() {
       return arguments[0];
     };
-
     List.prototype.change = function(item) {
       this.current = item;
       if (!this.current) {
@@ -34,9 +34,10 @@
       this.children().removeClass('active');
       return this.children().forItem(this.current).addClass('active');
     };
-
     List.prototype.render = function(items) {
-      if (items) this.items = items;
+      if (items) {
+        this.items = items;
+      }
       this.html(this.template(this.items));
       this.change(this.current);
       if (this.selectFirst) {
@@ -45,24 +46,18 @@
         }
       }
     };
-
     List.prototype.children = function(sel) {
       return this.el.children(sel);
     };
-
     List.prototype.click = function(e) {
       var item;
       item = $(e.currentTarget).item();
       this.trigger('change', item);
       return false;
     };
-
     return List;
-
   })();
-
   if (typeof module !== "undefined" && module !== null) {
     module.exports = Spine.List;
   }
-
 }).call(this);

--- a/lib/local.js
+++ b/lib/local.js
@@ -1,6 +1,7 @@
-
-  if (typeof Spine === "undefined" || Spine === null) Spine = require('spine');
-
+(function() {
+  if (typeof Spine === "undefined" || Spine === null) {
+    Spine = require('spine');
+  }
   Spine.Model.Local = {
     extended: function() {
       this.change(this.saveLocal);
@@ -19,7 +20,7 @@
       });
     }
   };
-
   if (typeof module !== "undefined" && module !== null) {
     module.exports = Spine.Model.Local;
   }
+}).call(this);

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -1,23 +1,25 @@
 (function() {
   var $;
-  var __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; }, __slice = Array.prototype.slice;
-
-  if (typeof Spine === "undefined" || Spine === null) Spine = require('spine');
-
+  var __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) {
+    for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; }
+    function ctor() { this.constructor = child; }
+    ctor.prototype = parent.prototype;
+    child.prototype = new ctor;
+    child.__super__ = parent.prototype;
+    return child;
+  }, __slice = Array.prototype.slice, __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
+  if (typeof Spine === "undefined" || Spine === null) {
+    Spine = require('spine');
+  }
   $ = Spine.$;
-
   Spine.Manager = (function() {
-
     __extends(Manager, Spine.Module);
-
     Manager.include(Spine.Events);
-
     function Manager() {
       this.controllers = [];
       this.bind('change', this.change);
       this.add.apply(this, arguments);
     }
-
     Manager.prototype.add = function() {
       var cont, controllers, _i, _len, _results;
       controllers = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
@@ -28,24 +30,20 @@
       }
       return _results;
     };
-
     Manager.prototype.addOne = function(controller) {
-      var _this = this;
-      controller.bind('active', function() {
+      controller.bind('active', __bind(function() {
         var args;
         args = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
-        return _this.trigger.apply(_this, ['change', controller].concat(__slice.call(args)));
-      });
-      controller.bind('release', function() {
-        return _this.controllers.splice(_this.controllers.indexOf(controller), 1);
-      });
+        return this.trigger.apply(this, ['change', controller].concat(__slice.call(args)));
+      }, this));
+      controller.bind('release', __bind(function() {
+        return this.controllers.splice(this.controllers.indexOf(controller), 1);
+      }, this));
       return this.controllers.push(controller);
     };
-
     Manager.prototype.deactivate = function() {
       return this.trigger.apply(this, ['change', false].concat(__slice.call(arguments)));
     };
-
     Manager.prototype.change = function() {
       var args, cont, current, _i, _len, _ref, _results;
       current = arguments[0], args = 2 <= arguments.length ? __slice.call(arguments, 1) : [];
@@ -53,19 +51,12 @@
       _results = [];
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
         cont = _ref[_i];
-        if (cont === current) {
-          _results.push(cont.activate.apply(cont, args));
-        } else {
-          _results.push(cont.deactivate.apply(cont, args));
-        }
+        _results.push(cont === current ? cont.activate.apply(cont, args) : cont.deactivate.apply(cont, args));
       }
       return _results;
     };
-
     return Manager;
-
   })();
-
   Spine.Controller.include({
     active: function() {
       var args;
@@ -90,27 +81,22 @@
       return this;
     }
   });
-
   Spine.Stack = (function() {
-
     __extends(Stack, Spine.Controller);
-
     Stack.prototype.controllers = {};
-
     Stack.prototype.routes = {};
-
     Stack.prototype.className = 'spine stack';
-
     function Stack() {
       var key, value, _fn, _ref, _ref2;
-      var _this = this;
       Stack.__super__.constructor.apply(this, arguments);
       this.manager = new Spine.Manager;
-      this.manager.bind('change', function() {
+      this.manager.bind('change', __bind(function() {
         var args, controller;
         controller = arguments[0], args = 2 <= arguments.length ? __slice.call(arguments, 1) : [];
-        if (controller) return _this.active.apply(_this, args);
-      });
+        if (controller) {
+          return this.active.apply(this, args);
+        }
+      }, this));
       _ref = this.controllers;
       for (key in _ref) {
         value = _ref[key];
@@ -120,33 +106,32 @@
         this.add(this[key]);
       }
       _ref2 = this.routes;
-      _fn = function(key, value) {
+      _fn = __bind(function(key, value) {
         var callback;
-        if (typeof value === 'function') callback = value;
-        callback || (callback = function() {
+        if (typeof value === 'function') {
+          callback = value;
+        }
+        callback || (callback = __bind(function() {
           var _ref3;
-          return (_ref3 = _this[value]).active.apply(_ref3, arguments);
-        });
-        return _this.route(key, callback);
-      };
+          return (_ref3 = this[value]).active.apply(_ref3, arguments);
+        }, this));
+        return this.route(key, callback);
+      }, this);
       for (key in _ref2) {
         value = _ref2[key];
         _fn(key, value);
       }
-      if (this["default"]) this[this["default"]].active();
+      if (this["default"]) {
+        this[this["default"]].active();
+      }
     }
-
     Stack.prototype.add = function(controller) {
       this.manager.add(controller);
       return this.append(controller);
     };
-
     return Stack;
-
   })();
-
   if (typeof module !== "undefined" && module !== null) {
     module.exports = Spine.Manager;
   }
-
 }).call(this);

--- a/lib/relation.js
+++ b/lib/relation.js
@@ -1,73 +1,69 @@
 (function() {
   var Collection, Instance, Singleton, singularize, underscore;
-  var __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; };
-
-  if (typeof Spine === "undefined" || Spine === null) Spine = require('spine');
-
+  var __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) {
+    for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; }
+    function ctor() { this.constructor = child; }
+    ctor.prototype = parent.prototype;
+    child.prototype = new ctor;
+    child.__super__ = parent.prototype;
+    return child;
+  }, __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
+  if (typeof Spine === "undefined" || Spine === null) {
+    Spine = require('spine');
+  }
   if (typeof require === "undefined" || require === null) {
     require = (function(value) {
       return eval(value);
     });
   }
-
   Collection = (function() {
-
     __extends(Collection, Spine.Module);
-
     function Collection(options) {
       var key, value;
-      if (options == null) options = {};
+      if (options == null) {
+        options = {};
+      }
       for (key in options) {
         value = options[key];
         this[key] = value;
       }
     }
-
     Collection.prototype.all = function() {
-      var _this = this;
-      return this.model.select(function(rec) {
-        return _this.associated(rec);
-      });
+      return this.model.select(__bind(function(rec) {
+        return this.associated(rec);
+      }, this));
     };
-
     Collection.prototype.first = function() {
       return this.all()[0];
     };
-
     Collection.prototype.last = function() {
       var values;
       values = this.all();
       return values[values.length - 1];
     };
-
     Collection.prototype.find = function(id) {
       var records;
-      var _this = this;
-      records = this.select(function(rec) {
+      records = this.select(__bind(function(rec) {
         return rec.id + '' === id + '';
-      });
-      if (!records[0]) throw 'Unknown record';
+      }, this));
+      if (!records[0]) {
+        throw 'Unknown record';
+      }
       return records[0];
     };
-
     Collection.prototype.findAllByAttribute = function(name, value) {
-      var _this = this;
-      return this.model.select(function(rec) {
+      return this.model.select(__bind(function(rec) {
         return rec[name] === value;
-      });
+      }, this));
     };
-
     Collection.prototype.findByAttribute = function(name, value) {
       return this.findAllByAttribute(name, value)[0];
     };
-
     Collection.prototype.select = function(cb) {
-      var _this = this;
-      return this.model.select(function(rec) {
-        return _this.associated(rec) && cb(rec);
-      });
+      return this.model.select(__bind(function(rec) {
+        return this.associated(rec) && cb(rec);
+      }, this));
     };
-
     Collection.prototype.refresh = function(values) {
       var record, records, value, _i, _j, _len, _len2;
       records = this.all();
@@ -84,86 +80,75 @@
       }
       return this.model.trigger('refresh');
     };
-
     Collection.prototype.create = function(record) {
       record[this.fkey] = this.record.id;
       return this.model.create(record);
     };
-
     Collection.prototype.associated = function(record) {
       return record[this.fkey] === this.record.id;
     };
-
     return Collection;
-
   })();
-
   Instance = (function() {
-
     __extends(Instance, Spine.Module);
-
     function Instance(options) {
       var key, value;
-      if (options == null) options = {};
+      if (options == null) {
+        options = {};
+      }
       for (key in options) {
         value = options[key];
         this[key] = value;
       }
     }
-
     Instance.prototype.exists = function() {
       return this.record[this.fkey] && this.model.exists(this.record[this.fkey]);
     };
-
     Instance.prototype.update = function(value) {
       return this.record[this.fkey] = value && value.id;
     };
-
     return Instance;
-
   })();
-
   Singleton = (function() {
-
     __extends(Singleton, Spine.Module);
-
     function Singleton(options) {
       var key, value;
-      if (options == null) options = {};
+      if (options == null) {
+        options = {};
+      }
       for (key in options) {
         value = options[key];
         this[key] = value;
       }
     }
-
     Singleton.prototype.find = function() {
       return this.record.id && this.model.findByAttribute(this.fkey, this.record.id);
     };
-
     Singleton.prototype.update = function(value) {
-      if (!(value instanceof this.model)) value = this.model.fromJSON(value);
+      if (!(value instanceof this.model)) {
+        value = this.model.fromJSON(value);
+      }
       value[this.fkey] = this.record.id;
       return value.save();
     };
-
     return Singleton;
-
   })();
-
   singularize = function(str) {
     return str.replace(/s$/, '');
   };
-
   underscore = function(str) {
     return str.replace(/::/g, '/').replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2').replace(/([a-z\d])([A-Z])/g, '$1_$2').replace(/-/g, '_').toLowerCase();
   };
-
   Spine.Model.extend({
     hasMany: function(name, model, fkey) {
       var association;
-      if (fkey == null) fkey = "" + (underscore(this.className)) + "_id";
+      if (fkey == null) {
+        fkey = "" + (underscore(this.className)) + "_id";
+      }
       association = function(record) {
-        if (typeof model === 'string') model = require(model);
+        if (typeof model === 'string') {
+          model = require(model);
+        }
         return new Collection({
           name: name,
           model: model,
@@ -172,15 +157,21 @@
         });
       };
       return this.prototype[name] = function(value) {
-        if (value != null) association(this).refresh(value);
+        if (value != null) {
+          association(this).refresh(value);
+        }
         return association(this);
       };
     },
     belongsTo: function(name, model, fkey) {
       var association;
-      if (fkey == null) fkey = "" + (singularize(name)) + "_id";
+      if (fkey == null) {
+        fkey = "" + (singularize(name)) + "_id";
+      }
       association = function(record) {
-        if (typeof model === 'string') model = require(model);
+        if (typeof model === 'string') {
+          model = require(model);
+        }
         return new Instance({
           name: name,
           model: model,
@@ -189,16 +180,22 @@
         });
       };
       this.prototype[name] = function(value) {
-        if (value != null) association(this).update(value);
+        if (value != null) {
+          association(this).update(value);
+        }
         return association(this).exists();
       };
       return this.attributes.push(fkey);
     },
     hasOne: function(name, model, fkey) {
       var association;
-      if (fkey == null) fkey = "" + (underscore(this.className)) + "_id";
+      if (fkey == null) {
+        fkey = "" + (underscore(this.className)) + "_id";
+      }
       association = function(record) {
-        if (typeof model === 'string') model = require(model);
+        if (typeof model === 'string') {
+          model = require(model);
+        }
         return new Singleton({
           name: name,
           model: model,
@@ -207,10 +204,11 @@
         });
       };
       return this.prototype[name] = function(value) {
-        if (value != null) association(this).update(value);
+        if (value != null) {
+          association(this).update(value);
+        }
         return association(this).find();
       };
     }
   });
-
 }).call(this);

--- a/lib/route.js
+++ b/lib/route.js
@@ -1,35 +1,31 @@
 (function() {
   var $, escapeRegExp, hashStrip, namedParam, splatParam;
-  var __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; }, __slice = Array.prototype.slice;
-
-  if (typeof Spine === "undefined" || Spine === null) Spine = require('spine');
-
+  var __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) {
+    for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; }
+    function ctor() { this.constructor = child; }
+    ctor.prototype = parent.prototype;
+    child.prototype = new ctor;
+    child.__super__ = parent.prototype;
+    return child;
+  }, __slice = Array.prototype.slice;
+  if (typeof Spine === "undefined" || Spine === null) {
+    Spine = require('spine');
+  }
   $ = Spine.$;
-
   hashStrip = /^#*/;
-
   namedParam = /:([\w\d]+)/g;
-
   splatParam = /\*([\w\d]+)/g;
-
   escapeRegExp = /[-[\]{}()+?.,\\^$|#\s]/g;
-
   Spine.Route = (function() {
-
     __extends(Route, Spine.Module);
-
     Route.extend(Spine.Events);
-
     Route.historySupport = "history" in window;
-
     Route.routes = [];
-
     Route.options = {
       trigger: true,
       history: false,
       shim: false
     };
-
     Route.add = function(path, callback) {
       var key, value, _results;
       if (typeof path === "object" && !(path instanceof RegExp)) {
@@ -43,14 +39,17 @@
         return this.routes.push(new this(path, callback));
       }
     };
-
     Route.setup = function(options) {
-      if (options == null) options = {};
+      if (options == null) {
+        options = {};
+      }
       this.options = $.extend({}, this.options, options);
       if (this.options.history) {
         this.history = this.historySupport && this.options.history;
       }
-      if (this.options.shim) return;
+      if (this.options.shim) {
+        return;
+      }
       if (this.history) {
         $(window).bind("popstate", this.change);
       } else {
@@ -58,7 +57,6 @@
       }
       return this.change();
     };
-
     Route.unbind = function() {
       if (this.history) {
         return $(window).unbind("popstate", this.change);
@@ -66,7 +64,6 @@
         return $(window).unbind("hashchange", this.change);
       }
     };
-
     Route.navigate = function() {
       var args, lastArg, options, path;
       args = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
@@ -79,41 +76,43 @@
       }
       options = $.extend({}, this.options, options);
       path = args.join("/");
-      if (this.path === path) return;
+      if (this.path === path) {
+        return;
+      }
       this.path = path;
-      if (options.trigger) this.matchRoute(this.path, options);
-      if (options.shim) return;
+      if (options.trigger) {
+        this.matchRoute(this.path, options);
+      }
+      if (options.shim) {
+        return;
+      }
       if (this.history) {
         return history.pushState({}, document.title, this.getHost() + this.path);
       } else {
         return window.location.hash = this.path;
       }
     };
-
     Route.getPath = function() {
       return window.location.pathname;
     };
-
     Route.getHash = function() {
       return window.location.hash;
     };
-
     Route.getFragment = function() {
       return this.getHash().replace(hashStrip, "");
     };
-
     Route.getHost = function() {
       return (document.location + "").replace(this.getPath() + this.getHash(), "");
     };
-
     Route.change = function() {
       var path;
       path = this.history ? this.getPath() : this.getFragment();
-      if (path === this.path) return;
+      if (path === this.path) {
+        return;
+      }
       this.path = path;
       return this.matchRoute(this.path);
     };
-
     Route.matchRoute = function(path, options) {
       var route, _i, _len, _ref;
       _ref = this.routes;
@@ -125,7 +124,6 @@
         }
       }
     };
-
     function Route(path, callback) {
       var match;
       this.path = path;
@@ -141,12 +139,15 @@
         this.route = path;
       }
     }
-
     Route.prototype.match = function(path, options) {
       var i, match, param, params, _len;
-      if (options == null) options = {};
+      if (options == null) {
+        options = {};
+      }
       match = this.route.exec(path);
-      if (!match) return false;
+      if (!match) {
+        return false;
+      }
       options.match = match;
       params = match.slice(1);
       if (this.names.length) {
@@ -157,13 +158,9 @@
       }
       return this.callback.call(null, options) !== false;
     };
-
     return Route;
-
   })();
-
   Spine.Route.change = Spine.Route.proxy(Spine.Route.change);
-
   Spine.Controller.include({
     route: function(path, callback) {
       return Spine.Route.add(path, this.proxy(callback));
@@ -181,9 +178,7 @@
       return Spine.Route.navigate.apply(Spine.Route, arguments);
     }
   });
-
   if (typeof module !== "undefined" && module !== null) {
     module.exports = Spine.Route;
   }
-
 }).call(this);

--- a/lib/spine.js
+++ b/lib/spine.js
@@ -1,7 +1,18 @@
 (function() {
   var $, Controller, Events, Log, Model, Module, Spine, guid, isArray, isBlank, makeArray, moduleKeywords;
-  var __slice = Array.prototype.slice, __hasProp = Object.prototype.hasOwnProperty, __indexOf = Array.prototype.indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (__hasProp.call(this, i) && this[i] === item) return i; } return -1; }, __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; }, __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
-
+  var __slice = Array.prototype.slice, __indexOf = Array.prototype.indexOf || function(item) {
+    for (var i = 0, l = this.length; i < l; i++) {
+      if (this[i] === item) return i;
+    }
+    return -1;
+  }, __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; }, __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) {
+    for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; }
+    function ctor() { this.constructor = child; }
+    ctor.prototype = parent.prototype;
+    child.prototype = new ctor;
+    child.__super__ = parent.prototype;
+    return child;
+  };
   Events = {
     bind: function(ev, callback) {
       var calls, evs, name, _i, _len;
@@ -25,10 +36,14 @@
       args = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
       ev = args.shift();
       list = this.hasOwnProperty('_callbacks') && ((_ref = this._callbacks) != null ? _ref[ev] : void 0);
-      if (!list) return false;
+      if (!list) {
+        return false;
+      }
       for (_i = 0, _len = list.length; _i < _len; _i++) {
         callback = list[_i];
-        if (callback.apply(this, args) === false) break;
+        if (callback.apply(this, args) === false) {
+          break;
+        }
       }
       return true;
     },
@@ -39,118 +54,124 @@
         return this;
       }
       list = (_ref = this._callbacks) != null ? _ref[ev] : void 0;
-      if (!list) return this;
+      if (!list) {
+        return this;
+      }
       if (!callback) {
         delete this._callbacks[ev];
         return this;
       }
       for (i = 0, _len = list.length; i < _len; i++) {
         cb = list[i];
-        if (!(cb === callback)) continue;
-        list = list.slice();
-        list.splice(i, 1);
-        this._callbacks[ev] = list;
-        break;
+        if (cb === callback) {
+          list = list.slice();
+          list.splice(i, 1);
+          this._callbacks[ev] = list;
+          break;
+        }
       }
       return this;
     }
   };
-
   Log = {
     trace: true,
     logPrefix: '(App)',
     log: function() {
       var args;
       args = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
-      if (!this.trace) return;
-      if (typeof console === 'undefined') return;
-      if (this.logPrefix) args.unshift(this.logPrefix);
+      if (!this.trace) {
+        return;
+      }
+      if (typeof console === 'undefined') {
+        return;
+      }
+      if (this.logPrefix) {
+        args.unshift(this.logPrefix);
+      }
       console.log.apply(console, args);
       return this;
     }
   };
-
   moduleKeywords = ['included', 'extended'];
-
   Module = (function() {
-
     Module.include = function(obj) {
       var key, value, _ref;
-      if (!obj) throw 'include(obj) requires obj';
+      if (!obj) {
+        throw 'include(obj) requires obj';
+      }
       for (key in obj) {
         value = obj[key];
-        if (__indexOf.call(moduleKeywords, key) < 0) this.prototype[key] = value;
+        if (__indexOf.call(moduleKeywords, key) < 0) {
+          this.prototype[key] = value;
+        }
       }
-      if ((_ref = obj.included) != null) _ref.apply(this);
+      if ((_ref = obj.included) != null) {
+        _ref.apply(this);
+      }
       return this;
     };
-
     Module.extend = function(obj) {
       var key, value, _ref;
-      if (!obj) throw 'extend(obj) requires obj';
+      if (!obj) {
+        throw 'extend(obj) requires obj';
+      }
       for (key in obj) {
         value = obj[key];
-        if (__indexOf.call(moduleKeywords, key) < 0) this[key] = value;
+        if (__indexOf.call(moduleKeywords, key) < 0) {
+          this[key] = value;
+        }
       }
-      if ((_ref = obj.extended) != null) _ref.apply(this);
+      if ((_ref = obj.extended) != null) {
+        _ref.apply(this);
+      }
       return this;
     };
-
     Module.proxy = function(func) {
-      var _this = this;
-      return function() {
-        return func.apply(_this, arguments);
-      };
+      return __bind(function() {
+        return func.apply(this, arguments);
+      }, this);
     };
-
     Module.prototype.proxy = function(func) {
-      var _this = this;
-      return function() {
-        return func.apply(_this, arguments);
-      };
+      return __bind(function() {
+        return func.apply(this, arguments);
+      }, this);
     };
-
     function Module() {
-      if (typeof this.init === "function") this.init.apply(this, arguments);
+      if (typeof this.init === "function") {
+        this.init.apply(this, arguments);
+      }
     }
-
     return Module;
-
   })();
-
   Model = (function() {
-
     __extends(Model, Module);
-
     Model.extend(Events);
-
     Model.records = {};
-
     Model.attributes = [];
-
     Model.configure = function() {
       var attributes, name;
       name = arguments[0], attributes = 2 <= arguments.length ? __slice.call(arguments, 1) : [];
       this.className = name;
       this.records = {};
-      if (attributes.length) this.attributes = attributes;
+      if (attributes.length) {
+        this.attributes = attributes;
+      }
       this.attributes && (this.attributes = makeArray(this.attributes));
       this.attributes || (this.attributes = []);
       this.unbind();
       return this;
     };
-
     Model.toString = function() {
       return "" + this.className + "(" + (this.attributes.join(", ")) + ")";
     };
-
     Model.find = function(id) {
       var record;
       record = this.records[id];
-      if (!record) throw 'Unknown record';
+      if (!record) {
+        throw 'Unknown record';
+      }
       return record.clone();
     };
-
     Model.exists = function(id) {
       try {
         return this.find(id);
@@ -158,13 +179,18 @@
         return false;
       }
     };
-
     Model.refresh = function(values, options) {
       var record, records, _i, _len;
-      if (options == null) options = {};
-      if (options.clear) this.records = {};
+      if (options == null) {
+        options = {};
+      }
+      if (options.clear) {
+        this.records = {};
+      }
       records = this.fromJSON(values);
-      if (!isArray(records)) records = [records];
+      if (!isArray(records)) {
+        records = [records];
+      }
       for (_i = 0, _len = records.length; _i < _len; _i++) {
         record = records[_i];
         record.newRecord = false;
@@ -174,7 +200,6 @@
       this.trigger('refresh', !options.clear && records);
       return this;
     };
-
     Model.select = function(callback) {
       var id, record, result;
       result = (function() {
@@ -183,29 +208,30 @@
         _results = [];
         for (id in _ref) {
           record = _ref[id];
-          if (callback(record)) _results.push(record);
+          if (callback(record)) {
+            _results.push(record);
+          }
         }
         return _results;
       }).call(this);
       return this.cloneArray(result);
     };
-
     Model.findByAttribute = function(name, value) {
       var id, record, _ref;
       _ref = this.records;
       for (id in _ref) {
         record = _ref[id];
-        if (record[name] === value) return record.clone();
+        if (record[name] === value) {
+          return record.clone();
+        }
       }
       return null;
     };
-
     Model.findAllByAttribute = function(name, value) {
       return this.select(function(item) {
         return item[name] === value;
       });
     };
-
     Model.each = function(callback) {
       var key, value, _ref, _results;
       _ref = this.records;
@@ -216,28 +242,23 @@
       }
       return _results;
     };
-
     Model.all = function() {
       return this.cloneArray(this.recordsValues());
     };
-
     Model.first = function() {
       var record;
       record = this.recordsValues()[0];
       return record != null ? record.clone() : void 0;
     };
-
     Model.last = function() {
       var record, values;
       values = this.recordsValues();
       record = values[values.length - 1];
       return record != null ? record.clone() : void 0;
     };
-
     Model.count = function() {
       return this.recordsValues().length;
     };
-
     Model.deleteAll = function() {
       var key, value, _ref, _results;
       _ref = this.records;
@@ -248,7 +269,6 @@
       }
       return _results;
     };
-
     Model.destroyAll = function() {
       var key, value, _ref, _results;
       _ref = this.records;
@@ -259,21 +279,17 @@
       }
       return _results;
     };
-
     Model.update = function(id, atts, options) {
       return this.find(id).updateAttributes(atts, options);
     };
-
     Model.create = function(atts, options) {
       var record;
       record = new this(atts);
       return record.save(options);
     };
-
     Model.destroy = function(id) {
       return this.find(id).destroy();
     };
-
     Model.change = function(callbackOrParams) {
       if (typeof callbackOrParams === 'function') {
         return this.bind('change', callbackOrParams);
@@ -281,7 +297,6 @@
         return this.trigger('change', callbackOrParams);
       }
     };
-
     Model.fetch = function(callbackOrParams) {
       if (typeof callbackOrParams === 'function') {
         return this.bind('fetch', callbackOrParams);
@@ -289,15 +304,17 @@
         return this.trigger('fetch', callbackOrParams);
       }
     };
-
     Model.toJSON = function() {
       return this.recordsValues();
     };
-
     Model.fromJSON = function(objects) {
       var value, _i, _len, _results;
-      if (!objects) return;
-      if (typeof objects === 'string') objects = JSON.parse(objects);
+      if (!objects) {
+        return;
+      }
+      if (typeof objects === 'string') {
+        objects = JSON.parse(objects);
+      }
       if (isArray(objects)) {
         _results = [];
         for (_i = 0, _len = objects.length; _i < _len; _i++) {
@@ -309,12 +326,10 @@
         return new this(objects);
       }
     };
-
     Model.fromForm = function() {
       var _ref;
       return (_ref = new this).fromForm.apply(_ref, arguments);
     };
-
     Model.recordsValues = function() {
       var key, result, value, _ref;
       result = [];
@@ -325,7 +340,6 @@
       }
       return result;
     };
-
     Model.cloneArray = function(array) {
       var value, _i, _len, _results;
       _results = [];
@@ -335,25 +349,21 @@
       }
       return _results;
     };
-
     Model.prototype.newRecord = true;
-
     function Model(atts) {
       Model.__super__.constructor.apply(this, arguments);
       this.ids = [];
-      if (atts) this.load(atts);
+      if (atts) {
+        this.load(atts);
+      }
     }
-
     Model.prototype.isNew = function() {
       return this.newRecord;
     };
-
     Model.prototype.isValid = function() {
       return !this.validate();
     };
-
     Model.prototype.validate = function() {};
-
     Model.prototype.load = function(atts) {
       var key, value;
       for (key in atts) {
@@ -366,7 +376,6 @@
       }
       return this;
     };
-
     Model.prototype.attributes = function() {
       var key, result, _i, _len, _ref;
       result = {};
@@ -381,18 +390,20 @@
           }
         }
       }
-      if (this.id) result.id = this.id;
+      if (this.id) {
+        result.id = this.id;
+      }
       return result;
     };
-
     Model.prototype.eql = function(rec) {
       var _ref, _ref2;
       return rec && rec.constructor === this.constructor && (rec.id === this.id || (_ref = this.id, __indexOf.call(rec.ids, _ref) >= 0) || (_ref2 = rec.id, __indexOf.call(this.ids, _ref2) >= 0));
     };
-
     Model.prototype.save = function(options) {
       var error, record;
-      if (options == null) options = {};
+      if (options == null) {
+        options = {};
+      }
       if (options.validate !== false) {
         error = this.validate();
         if (error) {
@@ -405,17 +416,14 @@
       this.trigger('save', options);
       return record;
     };
-
     Model.prototype.updateAttribute = function(name, value) {
       this[name] = value;
       return this.save();
     };
-
     Model.prototype.updateAttributes = function(atts, options) {
       this.load(atts);
       return this.save(options);
     };
-
     Model.prototype.changeID = function(id) {
       var records;
       this.ids.push(this.id);
@@ -425,9 +433,10 @@
       this.id = id;
       return this.save();
     };
-
     Model.prototype.destroy = function(options) {
-      if (options == null) options = {};
+      if (options == null) {
+        options = {};
+      }
       this.trigger('beforeDestroy', options);
       delete this.constructor.records[this.id];
       this.destroyed = true;
@@ -436,7 +445,6 @@
       this.unbind();
       return this;
     };
-
     Model.prototype.dup = function(newRecord) {
       var result;
       result = new this.constructor(this.attributes());
@@ -447,27 +455,24 @@
       }
       return result;
     };
-
     Model.prototype.clone = function() {
       return Object.create(this);
     };
-
     Model.prototype.reload = function() {
       var original;
-      if (this.newRecord) return this;
+      if (this.newRecord) {
+        return this;
+      }
       original = this.constructor.find(this.id);
       this.load(original.attributes());
       return original;
     };
-
     Model.prototype.toJSON = function() {
       return this.attributes();
     };
-
     Model.prototype.toString = function() {
       return "<" + this.constructor.className + " (" + (JSON.stringify(this)) + ")>";
     };
-
     Model.prototype.fromForm = function(form) {
       var key, result, _i, _len, _ref;
       result = {};
@@ -478,11 +483,9 @@
       }
       return this.load(result);
     };
-
     Model.prototype.exists = function() {
       return this.id && this.id in this.constructor.records;
     };
-
     Model.prototype.update = function(options) {
       var clone, records;
       this.trigger('beforeUpdate', options);
@@ -493,11 +496,12 @@
       clone.trigger('change', 'update', options);
       return clone;
     };
-
     Model.prototype.create = function(options) {
       var clone, records;
       this.trigger('beforeCreate', options);
-      if (!this.id) this.id = guid();
+      if (!this.id) {
+        this.id = guid();
+      }
       this.newRecord = false;
       records = this.constructor.records;
       records[this.id] = this.dup(false);
@@ -506,58 +510,45 @@
       clone.trigger('change', 'create', options);
       return clone;
     };
-
     Model.prototype.bind = function(events, callback) {
       var binder, unbinder;
-      var _this = this;
-      this.constructor.bind(events, binder = function(record) {
-        if (record && _this.eql(record)) return callback.apply(_this, arguments);
-      });
-      this.constructor.bind('unbind', unbinder = function(record) {
-        if (record && _this.eql(record)) {
-          _this.constructor.unbind(events, binder);
-          return _this.constructor.unbind('unbind', unbinder);
+      this.constructor.bind(events, binder = __bind(function(record) {
+        if (record && this.eql(record)) {
+          return callback.apply(this, arguments);
         }
-      });
+      }, this));
+      this.constructor.bind('unbind', unbinder = __bind(function(record) {
+        if (record && this.eql(record)) {
+          this.constructor.unbind(events, binder);
+          return this.constructor.unbind('unbind', unbinder);
+        }
+      }, this));
       return binder;
     };
-
     Model.prototype.one = function(events, callback) {
       var binder;
-      var _this = this;
-      return binder = this.bind(events, function() {
-        _this.constructor.unbind(events, binder);
-        return callback.apply(_this);
-      });
+      return binder = this.bind(events, __bind(function() {
+        this.constructor.unbind(events, binder);
+        return callback.apply(this);
+      }, this));
     };
-
     Model.prototype.trigger = function() {
       var args, _ref;
       args = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
       args.splice(1, 0, this);
       return (_ref = this.constructor).trigger.apply(_ref, args);
     };
-
     Model.prototype.unbind = function() {
       return this.trigger('unbind');
     };
-
     return Model;
-
   })();
-
   Controller = (function() {
-
     __extends(Controller, Module);
-
     Controller.include(Events);
-
     Controller.include(Log);
-
     Controller.prototype.eventSplitter = /^(\S+)\s*(.*)$/;
-
     Controller.prototype.tag = 'div';
-
     function Controller(options) {
       this.release = __bind(this.release, this);
       var key, value, _ref;
@@ -567,19 +558,30 @@
         value = _ref[key];
         this[key] = value;
       }
-      if (!this.el) this.el = document.createElement(this.tag);
+      if (!this.el) {
+        this.el = document.createElement(this.tag);
+      }
       this.el = $(this.el);
-      if (this.className) this.el.addClass(this.className);
+      if (this.className) {
+        this.el.addClass(this.className);
+      }
       this.release(function() {
         return this.el.remove();
       });
-      if (!this.events) this.events = this.constructor.events;
-      if (!this.elements) this.elements = this.constructor.elements;
-      if (this.events) this.delegateEvents();
-      if (this.elements) this.refreshElements();
+      if (!this.events) {
+        this.events = this.constructor.events;
+      }
+      if (!this.elements) {
+        this.elements = this.constructor.elements;
+      }
+      if (this.events) {
+        this.delegateEvents();
+      }
+      if (this.elements) {
+        this.refreshElements();
+      }
       Controller.__super__.constructor.apply(this, arguments);
     }
-
     Controller.prototype.release = function(callback) {
       if (typeof callback === 'function') {
         return this.bind('release', callback);
@@ -587,30 +589,25 @@
         return this.trigger('release');
       }
     };
-
     Controller.prototype.$ = function(selector) {
       return $(selector, this.el);
     };
-
     Controller.prototype.delegateEvents = function() {
       var eventName, key, match, method, selector, _ref, _results;
       _ref = this.events;
       _results = [];
       for (key in _ref) {
         method = _ref[key];
-        if (typeof method !== 'function') method = this.proxy(this[method]);
+        if (typeof method !== 'function') {
+          method = this.proxy(this[method]);
+        }
         match = key.match(this.eventSplitter);
         eventName = match[1];
         selector = match[2];
-        if (selector === '') {
-          _results.push(this.el.bind(eventName, method));
-        } else {
-          _results.push(this.el.delegate(selector, eventName, method));
-        }
+        _results.push(selector === '' ? this.el.bind(eventName, method) : this.el.delegate(selector, eventName, method));
       }
       return _results;
     };
-
     Controller.prototype.refreshElements = function() {
       var key, value, _ref, _results;
       _ref = this.elements;
@@ -621,17 +618,14 @@
       }
       return _results;
     };
-
     Controller.prototype.delay = function(func, timeout) {
       return setTimeout(this.proxy(func), timeout || 0);
     };
-
     Controller.prototype.html = function(element) {
       this.el.html(element.el || element);
       this.refreshElements();
       return this.el;
     };
-
     Controller.prototype.append = function() {
       var e, elements, _ref;
       elements = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
@@ -648,13 +642,11 @@
       this.refreshElements();
       return this.el;
     };
-
     Controller.prototype.appendTo = function(element) {
       this.el.appendTo(element.el || element);
       this.refreshElements();
       return this.el;
     };
-
     Controller.prototype.prepend = function() {
       var e, elements, _ref;
       elements = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
@@ -671,7 +663,6 @@
       this.refreshElements();
       return this.el;
     };
-
     Controller.prototype.replace = function(element) {
       var previous, _ref;
       _ref = [this.el, element.el || element], previous = _ref[0], this.el = _ref[1];
@@ -680,15 +671,11 @@
       this.refreshElements();
       return this.el;
     };
-
     return Controller;
-
   })();
-
   $ = this.jQuery || this.Zepto || function(element) {
     return element;
   };
-
   if (typeof Object.create !== 'function') {
     Object.create = function(o) {
       var Func;
@@ -697,24 +684,22 @@
       return new Func();
     };
   }
-
   isArray = function(value) {
     return Object.prototype.toString.call(value) === '[object Array]';
   };
-
   isBlank = function(value) {
     var key;
-    if (!value) return true;
+    if (!value) {
+      return true;
+    }
     for (key in value) {
       return false;
     }
     return true;
   };
-
   makeArray = function(args) {
     return Array.prototype.slice.call(args, 0);
   };
-
   guid = function() {
     return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
       var r, v;
@@ -723,72 +708,57 @@
       return v.toString(16);
     }).toUpperCase();
   };
-
   Spine = this.Spine = {};
-
-  if (typeof module !== "undefined" && module !== null) module.exports = Spine;
-
+  if (typeof module !== "undefined" && module !== null) {
+    module.exports = Spine;
+  }
   Spine.version = '1.0.5';
-
   Spine.isArray = isArray;
-
   Spine.isBlank = isBlank;
-
   Spine.$ = $;
-
   Spine.Events = Events;
-
   Spine.Log = Log;
-
   Spine.Module = Module;
-
   Spine.Controller = Controller;
-
   Spine.Model = Model;
-
   Module.extend.call(Spine, Events);
-
   Module.create = Module.sub = Controller.create = Controller.sub = Model.sub = function(instances, statics) {
     var result;
     result = (function() {
-
       __extends(result, this);
-
       function result() {
         result.__super__.constructor.apply(this, arguments);
       }
-
       return result;
-
     }).call(this);
-    if (instances) result.include(instances);
-    if (statics) result.extend(statics);
-    if (typeof result.unbind === "function") result.unbind();
+    if (instances) {
+      result.include(instances);
+    }
+    if (statics) {
+      result.extend(statics);
+    }
+    if (typeof result.unbind === "function") {
+      result.unbind();
+    }
     return result;
   };
-
   Model.setup = function(name, attributes) {
     var Instance;
-    if (attributes == null) attributes = [];
+    if (attributes == null) {
+      attributes = [];
+    }
     Instance = (function() {
-
       __extends(Instance, this);
-
       function Instance() {
         Instance.__super__.constructor.apply(this, arguments);
       }
-
       return Instance;
-
     }).call(this);
     Instance.configure.apply(Instance, [name].concat(__slice.call(attributes)));
     return Instance;
   };
-
   Module.init = Controller.init = Model.init = function(a1, a2, a3, a4, a5) {
     return new this(a1, a2, a3, a4, a5);
   };
-
   Spine.Class = Module;
-
 }).call(this);

--- a/lib/tabs.js
+++ b/lib/tabs.js
@@ -1,65 +1,61 @@
 (function() {
   var $;
-  var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; }, __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; };
-
-  if (typeof Spine === "undefined" || Spine === null) Spine = require('spine');
-
+  var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; }, __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) {
+    for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; }
+    function ctor() { this.constructor = child; }
+    ctor.prototype = parent.prototype;
+    child.prototype = new ctor;
+    child.__super__ = parent.prototype;
+    return child;
+  };
+  if (typeof Spine === "undefined" || Spine === null) {
+    Spine = require('spine');
+  }
   $ = Spine.$;
-
   Spine.Tabs = (function() {
-    var _this = this;
-
     __extends(Tabs, Spine.Controller);
-
     Tabs.prototype.events = {
       'click [data-name]': 'click'
     };
-
     function Tabs() {
       this.change = __bind(this.change, this);      Tabs.__super__.constructor.apply(this, arguments);
       this.bind('change', this.change);
     }
-
     Tabs.prototype.change = function(name) {
-      if (!name) return;
+      if (!name) {
+        return;
+      }
       this.current = name;
       this.children().removeClass('active');
       return this.children("[data-name=" + this.current + "]").addClass('active');
     };
-
     Tabs.prototype.render = function() {
       this.change(this.current);
       if (!(this.children('.active').length || this.current)) {
         return this.children(':first').click();
       }
     };
-
     Tabs.prototype.children = function(sel) {
       return this.el.children(sel);
     };
-
     Tabs.prototype.click = function(e) {
       var name;
       name = $(e.currentTarget).attr('data-name');
       return this.trigger('change', name);
     };
-
     Tabs.prototype.connect = function(tabName, controller) {
       return this.bind('change', function(name) {
-        if (name === tabName) return controller.active();
+        if (name === tabName) {
+          return controller.active();
+        }
       });
     };
-
-    controller.bind('active', function() {
-      return Tabs.change(tabName);
-    });
-
+    controller.bind('active', __bind(function() {
+      return this.change(tabName);
+    }, Tabs));
     return Tabs;
-
   }).call(this);
-
   if (typeof module !== "undefined" && module !== null) {
     module.exports = Spine.Tabs;
   }
-
 }).call(this);

--- a/lib/tmpl.js
+++ b/lib/tmpl.js
@@ -1,15 +1,12 @@
 (function() {
   var $;
-
   $ = typeof jQuery !== "undefined" && jQuery !== null ? jQuery : require("jqueryify");
-
   $.fn.item = function() {
     var item;
     item = $(this);
     item = item.data("item") || (typeof item.tmplItem === "function" ? item.tmplItem().data : void 0);
     return item != null ? typeof item.reload === "function" ? item.reload() : void 0 : void 0;
   };
-
   $.fn.forItem = function(item) {
     return this.filter(function() {
       var compare;
@@ -17,5 +14,4 @@
       return (typeof item.eql === "function" ? item.eql(compare) : void 0) || item === compare;
     });
   };
-
 }).call(this);

--- a/src/ajax.coffee
+++ b/src/ajax.coffee
@@ -166,7 +166,7 @@ Extend =
   ajax: -> new Collection(this)
 
   url: ->
-    "#{Model.host}/#{@className.toLowerCase()}s"
+    "#{Model.host}/#{@className.toLowerCase().pluralize()}"
       
 Model.Ajax =
   extended: ->

--- a/src/inflections.coffee
+++ b/src/inflections.coffee
@@ -1,0 +1,157 @@
+window.InflectionJS = null  if window and not window.InflectionJS
+InflectionJS =
+  uncountable_words: [ "equipment", "information", "rice", "money", "species", "series", "fish", "sheep", "moose", "deer", "news" ]
+  plural_rules: [ [ new RegExp("(m)an$", "gi"), "$1en" ], [ new RegExp("(pe)rson$", "gi"), "$1ople" ], [ new RegExp("(child)$", "gi"), "$1ren" ], [ new RegExp("^(ox)$", "gi"), "$1en" ], [ new RegExp("(ax|test)is$", "gi"), "$1es" ], [ new RegExp("(octop|vir)us$", "gi"), "$1i" ], [ new RegExp("(alias|status)$", "gi"), "$1es" ], [ new RegExp("(bu)s$", "gi"), "$1ses" ], [ new RegExp("(buffal|tomat|potat)o$", "gi"), "$1oes" ], [ new RegExp("([ti])um$", "gi"), "$1a" ], [ new RegExp("sis$", "gi"), "ses" ], [ new RegExp("(?:([^f])fe|([lr])f)$", "gi"), "$1$2ves" ], [ new RegExp("(hive)$", "gi"), "$1s" ], [ new RegExp("([^aeiouy]|qu)y$", "gi"), "$1ies" ], [ new RegExp("(x|ch|ss|sh)$", "gi"), "$1es" ], [ new RegExp("(matr|vert|ind)ix|ex$", "gi"), "$1ices" ], [ new RegExp("([m|l])ouse$", "gi"), "$1ice" ], [ new RegExp("(quiz)$", "gi"), "$1zes" ], [ new RegExp("s$", "gi"), "s" ], [ new RegExp("$", "gi"), "s" ] ]
+  singular_rules: [ [ new RegExp("(m)en$", "gi"), "$1an" ], [ new RegExp("(pe)ople$", "gi"), "$1rson" ], [ new RegExp("(child)ren$", "gi"), "$1" ], [ new RegExp("([ti])a$", "gi"), "$1um" ], [ new RegExp("((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)ses$", "gi"), "$1$2sis" ], [ new RegExp("(hive)s$", "gi"), "$1" ], [ new RegExp("(tive)s$", "gi"), "$1" ], [ new RegExp("(curve)s$", "gi"), "$1" ], [ new RegExp("([lr])ves$", "gi"), "$1f" ], [ new RegExp("([^fo])ves$", "gi"), "$1fe" ], [ new RegExp("([^aeiouy]|qu)ies$", "gi"), "$1y" ], [ new RegExp("(s)eries$", "gi"), "$1eries" ], [ new RegExp("(m)ovies$", "gi"), "$1ovie" ], [ new RegExp("(x|ch|ss|sh)es$", "gi"), "$1" ], [ new RegExp("([m|l])ice$", "gi"), "$1ouse" ], [ new RegExp("(bus)es$", "gi"), "$1" ], [ new RegExp("(o)es$", "gi"), "$1" ], [ new RegExp("(shoe)s$", "gi"), "$1" ], [ new RegExp("(cris|ax|test)es$", "gi"), "$1is" ], [ new RegExp("(octop|vir)i$", "gi"), "$1us" ], [ new RegExp("(alias|status)es$", "gi"), "$1" ], [ new RegExp("^(ox)en", "gi"), "$1" ], [ new RegExp("(vert|ind)ices$", "gi"), "$1ex" ], [ new RegExp("(matr)ices$", "gi"), "$1ix" ], [ new RegExp("(quiz)zes$", "gi"), "$1" ], [ new RegExp("s$", "gi"), "" ] ]
+  non_titlecased_words: [ "and", "or", "nor", "a", "an", "the", "so", "but", "to", "of", "at", "by", "from", "into", "on", "onto", "off", "out", "in", "over", "with", "for" ]
+  id_suffix: new RegExp("(_ids|_id)$", "g")
+  underbar: new RegExp("_", "g")
+  space_or_underbar: new RegExp("[ _]", "g")
+  uppercase: new RegExp("([A-Z])", "g")
+  underbar_prefix: new RegExp("^_")
+  apply_rules: (str, rules, skip, override) ->
+    if override
+      str = override
+    else
+      ignore = (skip.indexOf(str.toLowerCase()) > -1)
+      unless ignore
+        x = 0
+
+        while x < rules.length
+          if str.match(rules[x][0])
+            str = str.replace(rules[x][0], rules[x][1])
+            break
+          x++
+    str
+
+unless Array::indexOf
+  Array::indexOf = (item, fromIndex, compareFunc) ->
+    fromIndex = -1  unless fromIndex
+    index = -1
+    i = fromIndex
+
+    while i < @length
+      if this[i] is item or compareFunc and compareFunc(this[i], item)
+        index = i
+        break
+      i++
+    index
+String::_uncountable_words = InflectionJS.uncountable_words  unless String::_uncountable_words
+String::_plural_rules = InflectionJS.plural_rules  unless String::_plural_rules
+String::_singular_rules = InflectionJS.singular_rules  unless String::_singular_rules
+String::_non_titlecased_words = InflectionJS.non_titlecased_words  unless String::_non_titlecased_words
+unless String::pluralize
+  String::pluralize = (plural) ->
+    InflectionJS.apply_rules this, @_plural_rules, @_uncountable_words, plural
+unless String::singularize
+  String::singularize = (singular) ->
+    InflectionJS.apply_rules this, @_singular_rules, @_uncountable_words, singular
+unless String::camelize
+  String::camelize = (lowFirstLetter) ->
+    str = @toLowerCase()
+    str_path = str.split("/")
+    i = 0
+
+    while i < str_path.length
+      str_arr = str_path[i].split("_")
+      initX = (if (lowFirstLetter and i + 1 is str_path.length) then (1) else (0))
+      x = initX
+
+      while x < str_arr.length
+        str_arr[x] = str_arr[x].charAt(0).toUpperCase() + str_arr[x].substring(1)
+        x++
+      str_path[i] = str_arr.join("")
+      i++
+    str = str_path.join("::")
+    str
+unless String::underscore
+  String::underscore = ->
+    str = this
+    str_path = str.split("::")
+    i = 0
+
+    while i < str_path.length
+      str_path[i] = str_path[i].replace(InflectionJS.uppercase, "_$1")
+      str_path[i] = str_path[i].replace(InflectionJS.underbar_prefix, "")
+      i++
+    str = str_path.join("/").toLowerCase()
+    str
+unless String::humanize
+  String::humanize = (lowFirstLetter) ->
+    str = @toLowerCase()
+    str = str.replace(InflectionJS.id_suffix, "")
+    str = str.replace(InflectionJS.underbar, " ")
+    str = str.capitalize()  unless lowFirstLetter
+    str
+unless String::capitalize
+  String::capitalize = ->
+    str = @toLowerCase()
+    str = str.substring(0, 1).toUpperCase() + str.substring(1)
+    str
+unless String::dasherize
+  String::dasherize = ->
+    str = this
+    str = str.replace(InflectionJS.space_or_underbar, "-")
+    str
+unless String::titleize
+  String::titleize = ->
+    str = @toLowerCase()
+    str = str.replace(InflectionJS.underbar, " ")
+    str_arr = str.split(" ")
+    x = 0
+
+    while x < str_arr.length
+      d = str_arr[x].split("-")
+      i = 0
+
+      while i < d.length
+        d[i] = d[i].capitalize()  if @_non_titlecased_words.indexOf(d[i].toLowerCase()) < 0
+        i++
+      str_arr[x] = d.join("-")
+      x++
+    str = str_arr.join(" ")
+    str = str.substring(0, 1).toUpperCase() + str.substring(1)
+    str
+unless String::demodulize
+  String::demodulize = ->
+    str = this
+    str_arr = str.split("::")
+    str = str_arr[str_arr.length - 1]
+    str
+unless String::tableize
+  String::tableize = ->
+    str = this
+    str = str.underscore().pluralize()
+    str
+unless String::classify
+  String::classify = ->
+    str = this
+    str = str.camelize().singularize()
+    str
+unless String::foreign_key
+  String::foreign_key = (dropIdUbar) ->
+    str = this
+    str = str.demodulize().underscore() + (if (dropIdUbar) then ("") else ("_")) + "id"
+    str
+unless String::ordinalize
+  String::ordinalize = ->
+    str = this
+    str_arr = str.split(" ")
+    x = 0
+
+    while x < str_arr.length
+      i = parseInt(str_arr[x])
+      if i is NaN
+        ltd = str_arr[x].substring(str_arr[x].length - 2)
+        ld = str_arr[x].substring(str_arr[x].length - 1)
+        suf = "th"
+        if ltd isnt "11" and ltd isnt "12" and ltd isnt "13"
+          if ld is "1"
+            suf = "st"
+          else if ld is "2"
+            suf = "nd"
+          else suf = "rd"  if ld is "3"
+        str_arr[x] += suf
+      x++
+    str = str_arr.join(" ")
+    str

--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -483,7 +483,7 @@ guid = ->
 Spine = @Spine   = {}
 module?.exports  = Spine
 
-Spine.version    = '1.0.5'
+Spine.version    = '1.0.6'
 Spine.isArray    = isArray
 Spine.isBlank    = isBlank
 Spine.$          = $

--- a/test/ajax.html
+++ b/test/ajax.html
@@ -8,7 +8,8 @@
 
   <script src="lib/jquery.js" type="text/javascript" charset="utf-8"></script>
   <script src="../lib/spine.js" type="text/javascript" charset="utf-8"></script>
-  <script src="../lib/ajax.js" type="text/javascript" charset="utf-8"></script>
+  <script src="../lib/ajax.js" type="text/javascript" charset="utf-8"></script>  
+  <script src="../lib/inflections.js" type="text/javascript" charset="utf-8"></script>  
 
   <script src="specs/ajax.js" type="text/javascript" charset="utf-8"></script>
 </head>

--- a/test/specs/ajax.js
+++ b/test/specs/ajax.js
@@ -8,6 +8,9 @@ describe("Ajax", function(){
     
     User = Spine.Model.setup("User", ["first", "last"]);
     User.extend(Spine.Model.Ajax);
+    Story = Spine.Model.setup("Story", ["title", "description"]);
+    Story.extend(Spine.Model.Ajax);
+
     
     jqXHR = $.Deferred();
 
@@ -140,5 +143,21 @@ describe("Ajax", function(){
 
     it("should expose the defaults object", function(){
       expect(Spine.Ajax.defaults).toBeDefined();
+    });
+    
+    it("pluralizes correctly", function(){
+      spyOn(jQuery, "ajax").andReturn(jqXHR);
+
+      Story.create({title: "hello", description: "no", id: "IDD"});
+
+      expect(jQuery.ajax).toHaveBeenCalledWith({
+        type:         'POST', 
+        headers:      { 'X-Requested-With' : 'XMLHttpRequest' },
+        contentType:  'application/json', 
+        dataType:     'json', 
+        data:         '{"title":"hello","description":"no","id":"IDD"}', 
+        url:          '/stories', 
+        processData:  false
+      });
     });
 });


### PR DESCRIPTION
I am using spine with rails (using gem "spine-rails"). Pluralization is currently done "naively" by adding an "s" to the singular model name. Which results in incorrectly pluralizing "story" with "storys". 

The proposed patch uses a CoffeeScript version of https://github.com/rxgx/inflection-js/blob/master/inflection.js to have the pluralization compatible with Rails style pluralization. 

I did not want to change the original library except CoffeeScripting it, so there are methods in the lib that will be YANGI. Also  note that this modifies the String prototype which some consider to be extremely evil. 

Attached a test case, and tested under recent versions of Safari, Chrome and Firefox

I propose to bump the version as this is an api change. 
