### PR TITLE
Better CommonJS Module Support

### DIFF
--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -452,7 +452,7 @@ class Controller extends Module
 
 # Utilities & Shims
 
-$ = @jQuery or @Zepto or (element) -> element
+$ = window.jQuery or window.Zepto or (element) -> element
 
 unless typeof Object.create is 'function'
   Object.create = (o) ->


### PR DESCRIPTION
I'm enjoying using spine in pure couch apps, this was the only issue i've found so far. The scope of `this` is the commonjs module spine lives in, not necessarily the window.
