### PR TITLE
Pass options from the @destroy class method to the destroy instance method.

### DIFF
--- a/lib/spine.js
+++ b/lib/spine.js
@@ -270,8 +270,8 @@
       return record.save(options);
     };
 
-    Model.destroy = function(id) {
-      return this.find(id).destroy();
+    Model.destroy = function(id, options) {
+      return this.find(id).destroy(options);
     };
 
     Model.change = function(callbackOrParams) {

--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -171,8 +171,8 @@ class Model extends Module
     record = new @(atts)
     record.save(options)
 
-  @destroy: (id) ->
-    @find(id).destroy()
+  @destroy: (id, options) ->
+    @find(id).destroy(options)
 
   @change: (callbackOrParams) ->
     if typeof callbackOrParams is 'function'


### PR DESCRIPTION
I've been using the options in @update() and @create() to pass along information about the user performing the actions so that others can see who made the changes in realtime.  I noticed that @destroy was the only one of these methods that didn't pass along options to the instance method.

Would you be willing to add this for consistency?
