### PR TITLE
I made some fixes to route.coffee. I'd love to see them back in the master branch.

### DIFF
--- a/src/route.coffee
+++ b/src/route.coffee
@@ -76,7 +76,11 @@ class Spine.Route extends Spine.Module
     
   # Private
   
-  @getPath: -> if window.location.pathname.substr(0,1) is '/' then window.location.pathname else '/' + window.location.pathname
+  @getPath: -> 
+    path = window.location.pathname
+    if path.substr(0,1) isnt '/' 
+      path = '/' + path
+    path
   
   @getHash: -> window.location.hash
   


### PR DESCRIPTION
A couple of fixes:
-fix in @historysupport: history of window doesn't detect pushState support (IE8 for example does support window.history.back(), but it doesn't support window.history.pushState())
-fix in @getpath: make sure there is always a leading slash (<IE8 doesn't always give you a leading slash)
-fix in @change: make hashurls and normal urls interchangeable (http://example.com/#/about didn't trigger the /about route when pustState is enabled. That isn't very practical if you exchange urls with someone with an older browser)

One feature added:
-added a navigate event trigger in @navigate. (Useful for Analytics pageview tracking for example, since the change event isn't fired when options.trigger is false.)
