### PR TITLE
fix for regex.exec bug in IE

### DIFF
--- a/src/route.coffee
+++ b/src/route.coffee
@@ -105,6 +105,7 @@ class Spine.Route extends Spine.Module
     @names = []
 
     if typeof path is "string"
+      namedParam.lastIndex = 0
       while (match = namedParam.exec(path)) != null
         @names.push(match[1])
         


### PR DESCRIPTION
IE has a bug in regex.exec where it doesn't reset the internal
reference to regex.lastIndex when it begins a new cycle in the
construction "while (match = namedParam.exec(path))". This was causing
the params of the second route I registered to start at the index
that my first route left off.

Adding a line above the loop in route.coffee reseting
namedParam.lastIndex to 0 corrects this behavior and matches the
behavior of chrome. You can see it in my commit on line 108 of
routes.coffee.

Thank you for the amazing project!
