### PR TITLE
Little issue with $.fn.item and the returning value when item is not a record

### DIFF
--- a/lib/tmpl.js
+++ b/lib/tmpl.js
@@ -7,7 +7,8 @@
     var item;
     item = $(this);
     item = item.data("item") || (typeof item.tmplItem === "function" ? item.tmplItem().data : void 0);
-    return item != null ? typeof item.reload === "function" ? item.reload() : void 0 : void 0;
+    if (item != null) if (typeof item.reload === "function") item.reload();
+    return item;
   };
 
   $.fn.forItem = function(item) {

--- a/src/tmpl.coffee
+++ b/src/tmpl.coffee
@@ -6,6 +6,7 @@ $.fn.item = ->
   item = $(@)
   item = item.data("item") or item.tmplItem?().data
   item?.reload?()
+  item
 
 $.fn.forItem = (item) ->
   @filter ->


### PR DESCRIPTION
in `$.fn.item` if `item` is not a record, then `undefined` is returned rather `item` because of this :

``` coffeescript
foo = {}

console.log do ->
  foo?.reload?()
#> undefined

console.log do ->
  foo?.reload?()
  foo
#> {}
```

making the `Spine.List.click` trigger `Spine.List.change` with `undefined` as parameter, and thus fail updating the `current` item as illustrated [here](http://jsfiddle.net/abernier/n4KhR/3/) — PATCH applied.
