### PR TITLE
Add existence check to window when defining $

### DIFF
--- a/lib/spine.js
+++ b/lib/spine.js
@@ -707,7 +707,7 @@
 
   })(Module);
 
-  $ = window.jQuery || window.Zepto || function(element) {
+  $ = (typeof window !== "undefined" && window !== null ? window.jQuery : void 0) || (typeof window !== "undefined" && window !== null ? window.Zepto : void 0) || function(element) {
     return element;
   };
 

--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -470,7 +470,7 @@ class Controller extends Module
 
 # Utilities & Shims
 
-$ = window.jQuery or window.Zepto or (element) -> element
+$ = window?.jQuery or window?.Zepto or (element) -> element
 
 unless typeof Object.create is 'function'
   Object.create = (o) ->


### PR DESCRIPTION
When trying to require Spine from a Node (or other non browser) environment, it raises an error since window is undefined. Checking for existence removes this error.
