### PR TITLE
Refreshing or fetching hasOne and belongsTo associations can lead to create being called on the server.

### DIFF
--- a/lib/relation.js
+++ b/lib/relation.js
@@ -120,9 +120,8 @@
     };
 
     Instance.prototype.update = function(value) {
-      if (!(value instanceof this.model)) value = new this.model(value);
-      if (value.isNew()) value.save();
-      return this.record[this.fkey] = value && value.id;
+      this.record[this.fkey] = value && value.id;
+      return this.model.refresh(value);
     };
 
     return Instance;
@@ -147,9 +146,8 @@
     };
 
     Singleton.prototype.update = function(value) {
-      if (!(value instanceof this.model)) value = this.model.fromJSON(value);
       value[this.fkey] = this.record.id;
-      return value.save();
+      return this.model.refresh(value);
     };
 
     return Singleton;

--- a/src/relation.coffee
+++ b/src/relation.coffee
@@ -65,11 +65,9 @@ class Instance extends Spine.Module
     @record[@fkey] and @model.exists(@record[@fkey])
     
   update: (value) ->
-    unless value instanceof @model
-      value = new @model(value)
-    value.save() if value.isNew()
     @record[@fkey] = value and value.id
-    
+    @model.refresh(value)
+
 class Singleton extends Spine.Module
   constructor: (options = {}) ->
     for key, value of options
@@ -79,11 +77,8 @@ class Singleton extends Spine.Module
     @record.id and @model.findByAttribute(@fkey, @record.id)
 
   update: (value) ->
-    unless value instanceof @model
-      value = @model.fromJSON(value)
-    
     value[@fkey] = @record.id
-    value.save()
+    @model.refresh(value)
 
 singularize = (str) ->
   str.replace(/s$/, '')

--- a/test/ajax.html
+++ b/test/ajax.html
@@ -9,6 +9,7 @@
   <script src="lib/jquery.js" type="text/javascript" charset="utf-8"></script>
   <script src="../lib/spine.js" type="text/javascript" charset="utf-8"></script>
   <script src="../lib/ajax.js" type="text/javascript" charset="utf-8"></script>
+  <script src="../lib/relation.js" type="text/javascript" charset="utf-8"></script>
 
   <script src="specs/ajax.js" type="text/javascript" charset="utf-8"></script>
 </head>

--- a/test/specs/ajax.js
+++ b/test/specs/ajax.js
@@ -154,4 +154,18 @@ describe("Ajax", function(){
       expect(User.url()).toBe('http://example.com/users');
       expect(user.url()).toBe('http://example.com/users/1');
     });
+
+    it("should refresh a tree of objects without calling back to the server", function() {
+      spyOn(jQuery, "ajax").andReturn(jqXHR);
+      var Dog = Spine.Model.setup("Dog", ["name"]);
+      Dog.extend(Spine.Model.Ajax);
+      Dog.belongsTo("user", User);
+      User.hasOne("dog", Dog);
+
+      User.refresh({"id": 1, "first":"First", "last":"Last", "dog_id": 2, "dog": {"id":2, "name":"Dog"}});
+      expect(jQuery.ajax).not.toHaveBeenCalled();
+
+      Dog.refresh({"id":3, "name":"Dog", "user":{"id": 4, "first":"First", "last":"Last", "dog_id": 3}});
+      expect(jQuery.ajax).not.toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
``` javascript
var Human = Spine.Model.setup("Human", ["first", "last"]);
Human.extend(Spine.Model.Ajax);
var Dog = Spine.Model.setup("Dog", ["name"]);
Dog.extend(Spine.Model.Ajax);

Dog.belongsTo("human", Human);
Human.hasOne("dog", Dog);

//dog#create will be called on the server
Human.refresh({"id": 1, "first":"First", "last":"Last", "dog_id": 2, "dog": {"id":2, "name":"Dog"}}); 
```

The tests still pass, but there could be something I'm missing.
