### PR TITLE
Adding ```options = {}`` paramater to Spine.Model.Ajax.fetch

### DIFF
--- a/lib/ajax.js
+++ b/lib/ajax.js
@@ -107,18 +107,19 @@
       }).success(this.recordsResponse).error(this.errorResponse);
     };
 
-    Collection.prototype.fetch = function(params) {
+    Collection.prototype.fetch = function(params, options) {
       var id,
         _this = this;
       if (params == null) params = {};
+      if (options == null) options = {};
       if (id = params.id) {
         delete params.id;
         return this.find(id, params).success(function(record) {
-          return _this.model.refresh(record);
+          return _this.model.refresh(record, options);
         });
       } else {
         return this.all(params).success(function(records) {
-          return _this.model.refresh(records);
+          return _this.model.refresh(records, options);
         });
       }
     };

--- a/src/ajax.coffee
+++ b/src/ajax.coffee
@@ -70,15 +70,17 @@ class Collection extends Base
     ).success(@recordsResponse)
      .error(@errorResponse)
     
-  fetch: (params = {}) ->
+  fetch: (params = {}, options = {}) ->
     if id = params.id
       delete params.id
       @find(id, params).success (record) =>
-        @model.refresh(record)
+        @model.refresh(record, options)
     else
       @all(params).success (records) =>
-        @model.refresh(records)
-    
+        @model.refresh(records, options)
+
+  # Private
+
   recordsResponse: (data, status, xhr) =>
     @model.trigger('ajaxSuccess', null, status, xhr)
 
@@ -181,7 +183,9 @@ Model.Ajax =
     
     @extend Extend
     @include Include
-    
+
+  # Private
+
   ajaxFetch: ->
     @ajax().fetch(arguments...)
     


### PR DESCRIPTION
Sometimes, when fetching datas through `Spine.Model.Ajax.fetch`, we need to invalidate all records through `{clear: true}` option for the `@model.refresh` which is handled [here](https://github.com/maccman/spine/pull/191/files#L1L80).

Not so sure for a single record, but why not?
