### PR TITLE
Moves the error and success callbacks into the Ajax request options

### DIFF
--- a/src/ajax.coffee
+++ b/src/ajax.coffee
@@ -55,20 +55,20 @@ class Collection extends Base
     
   find: (id, params) ->
     record = new @model(id: id)
-    @ajax(
+    @ajax
       params,
       type: 'GET',
       url:  Ajax.getURL(record)
-    ).success(@recordsResponse)
-     .error(@errorResponse)
+      success: @recordsResponse
+      error: @errorResponse
     
   all: (params) ->
-    @ajax(
+    @ajax
       params,
       type: 'GET',
       url:  Ajax.getURL(@model)
-    ).success(@recordsResponse)
-     .error(@errorResponse)
+      success: @recordsResponse
+      error: @errorResponse
     
   fetch: (params = {}, options = {}) ->
     if id = params.id
@@ -97,8 +97,8 @@ class Singleton extends Base
         params,
         type: 'GET'
         url:  Ajax.getURL(@record)
-      ).success(@recordResponse(options))
-       .error(@errorResponse(options))
+        success: @recordResponse(options)
+        error: @errorResponse(options)
   
   create: (params, options) ->
     @queue =>
@@ -107,8 +107,8 @@ class Singleton extends Base
         type: 'POST'
         data: JSON.stringify(@record)
         url:  Ajax.getURL(@model)
-      ).success(@recordResponse(options))
-       .error(@errorResponse(options))
+        success: @recordResponse(options)
+        error: @errorResponse(options)
 
   update: (params, options) ->
     @queue =>
@@ -117,17 +117,17 @@ class Singleton extends Base
         type: 'PUT'
         data: JSON.stringify(@record)
         url:  Ajax.getURL(@record)
-      ).success(@recordResponse(options))
-       .error(@errorResponse(options))
+        success: @recordResponse(options)
+        error: @errorResponse(options)
   
   destroy: (params, options) ->
     @queue =>
-      @ajax(
+      @ajax
         params,
         type: 'DELETE'
         url:  Ajax.getURL(@record)
-      ).success(@recordResponse(options))
-       .error(@errorResponse(options))
+        success: @recordResponse(options)
+        error: @errorResponse(options)
 
   # Private
 


### PR DESCRIPTION
Was running into an issue in which I needed to prepend some code to each ajax callback. Moving the callbacks into the options object makes them available to jQuery.ajaxPrefilter() which gives a good place to hook on low-level logging/debugging code.
