### PR TITLE
Sets attrs specified in controller on @el

### DIFF
--- a/lib/spine.js
+++ b/lib/spine.js
@@ -592,6 +592,7 @@
       if (!this.el) this.el = document.createElement(this.tag);
       this.el = $(this.el);
       if (this.className) this.el.addClass(this.className);
+      if (this.attributes) this.el.attr(this.attributes);
       this.release(function() {
         return this.el.remove();
       });

--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -396,6 +396,7 @@ class Controller extends Module
     @el = $(@el)
 
     @el.addClass(@className) if @className
+    @el.attr(@attributes) if @attributes
 
     @release -> @el.remove()
 

--- a/test/specs/controller.js
+++ b/test/specs/controller.js
@@ -81,4 +81,13 @@ describe("Controller", function(){
       expect(spy).toHaveBeenCalled();
     });
   });
+
+  it("can set attributes on el", function(){
+    Users.include({
+      attributes: {"style": "width: 100%"}
+    });
+
+    var users = new Users();
+    expect(users.el.attr("style")).toEqual("width: 100%");
+  });
 });


### PR DESCRIPTION
Enables you to add an @attributes property on controllers and have those attributes set on @el. For example:

``` coffeescript
class MyController extends Spine.Controller
  @tag: "a"
  @attributes:
    title: "Home"
    href: "/home"
  # ...

# (new MyController).el => <a href="/home" title="Home">...</a>
```
