### PR TITLE
Making delegateEvents state-independent

### DIFF
--- a/lib/spine.js
+++ b/lib/spine.js
@@ -598,7 +598,7 @@
       });
       if (!this.events) this.events = this.constructor.events;
       if (!this.elements) this.elements = this.constructor.elements;
-      if (this.events) this.delegateEvents();
+      if (this.events) this.delegateEvents(this.events);
       if (this.elements) this.refreshElements();
       Controller.__super__.constructor.apply(this, arguments);
     }
@@ -615,12 +615,11 @@
       return $(selector, this.el);
     };
 
-    Controller.prototype.delegateEvents = function() {
-      var eventName, key, match, method, selector, _ref, _results;
-      _ref = this.events;
+    Controller.prototype.delegateEvents = function(events) {
+      var eventName, key, match, method, selector, _results;
       _results = [];
-      for (key in _ref) {
-        method = _ref[key];
+      for (key in events) {
+        method = events[key];
         if (typeof method !== 'function') method = this.proxy(this[method]);
         match = key.match(this.eventSplitter);
         eventName = match[1];
@@ -699,7 +698,7 @@
       var previous, _ref;
       _ref = [this.el, $(element.el || element)], previous = _ref[0], this.el = _ref[1];
       previous.replaceWith(this.el);
-      this.delegateEvents();
+      this.delegateEvents(this.events);
       this.refreshElements();
       return this.el;
     };

--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -403,7 +403,7 @@ class Controller extends Module
     @events = @constructor.events unless @events
     @elements = @constructor.elements unless @elements
 
-    @delegateEvents() if @events
+    @delegateEvents(@events) if @events
     @refreshElements() if @elements
 
     super
@@ -416,8 +416,8 @@ class Controller extends Module
 
   $: (selector) -> $(selector, @el)
 
-  delegateEvents: ->
-    for key, method of @events
+  delegateEvents: (events) ->
+    for key, method of events
       unless typeof(method) is 'function'
         method = @proxy(@[method])
 
@@ -462,7 +462,7 @@ class Controller extends Module
   replace: (element) ->
     [previous, @el] = [@el, $(element.el or element)]
     previous.replaceWith(@el)
-    @delegateEvents()
+    @delegateEvents(@events)
     @refreshElements()
     @el
 


### PR DESCRIPTION
Suppose you have controller `Form` and a subclass called `NiceForm`. 

Currently, if you want to support more events, you have to do this:

```
constructor: ->
  @events['click .nice'] = 'nice'
  super
```

While this API works well, it took me a few minutes to realize I have to set it before super. (Also, in most languages you can't/are not supposed to do anything before super in init, so one wouldn't think of it.)

Setting it **after** super would result in double delegating/handlers being called twice.

Thanks to this change, it will be possible to add events by simply calling @delegateEvents with an argument, like this:

```
constructor: ->
  super
  @delegateEvents 'click .nice': 'nice'
```
