### PR TITLE
Fix for ajax DELETE not working in recent versions of FF.

### DIFF
--- a/src/ajax.coffee
+++ b/src/ajax.coffee
@@ -125,6 +125,7 @@ class Singleton extends Base
       @ajax(
         params,
         type: 'DELETE'
+        data: null
         url:  Ajax.getURL(@record)
       ).success(@recordResponse(options))
        .error(@errorResponse(options))


### PR DESCRIPTION
Fixes the problem with NS_ERROR_CANNOT_CONVERT_DATA thrown by FF which results in an ajax error.
