### PR TITLE
Added history support for shimming

### DIFF
--- a/src/route.coffee
+++ b/src/route.coffee
@@ -19,7 +19,7 @@ class Spine.Route extends Spine.Module
     shim: false
         
   @add: (path, callback) ->
-    if (typeof path is "object" and path not instanceof RegExp)
+    if (typeof path is 'object' and path not instanceof RegExp)
       @add(key, value) for key, value of path
     else
       @routes.push(new @(path, callback))
@@ -30,40 +30,50 @@ class Spine.Route extends Spine.Module
     if (@options.history)
       @history = @historySupport && @options.history
       
-    return if @options.shim
-        
-    if @history 
-      $(window).bind("popstate", @change)
+    if @options.shim
+      if @history
+        $(window).bind('popstate', @change)
+      return
+
+    if @history
+      $(window).bind('popstate', @change)
     else
-      $(window).bind("hashchange", @change)
+      $(window).bind('hashchange', @change)
     @change() 
     
   @unbind: ->
     if @history
-      $(window).unbind("popstate", @change)
+      $(window).unbind('popstate', @change)
     else
-      $(window).unbind("hashchange", @change)
+      $(window).unbind('hashchange', @change)
     
   @navigate: (args...) ->
     options = {}
     
     lastArg = args[args.length - 1]
-    if typeof lastArg is "object"
+    if typeof lastArg is 'object'
       options = args.pop()
-    else if typeof lastArg is "boolean"
+    else if typeof lastArg is 'boolean'
       options.trigger = args.pop()
     
     options = $.extend({}, @options, options)
     
-    path = args.join("/")
+    path = args.join('/')
     return if @path is path
     @path = path
 
-    @trigger("navigate", @path)
+    @trigger('navigate', @path)
 
     @matchRoute(@path, options) if options.trigger
 
-    return if options.shim
+    if options.shim
+      if @history
+        history.pushState(
+          {path: @path},
+          document.title,
+          null
+        )
+      return
     
     if @history
       history.pushState(
@@ -84,13 +94,16 @@ class Spine.Route extends Spine.Module
   
   @getHash: -> window.location.hash
   
-  @getFragment: -> @getHash().replace(hashStrip, "")
+  @getFragment: -> @getHash().replace(hashStrip, '')
   
   @getHost: ->
-    (document.location + "").replace(@getPath() + @getHash(), "")
+    (document.location + '').replace(@getPath() + @getHash(), '')
     
-  @change: ->
-    path = if @getFragment() isnt "" then @getFragment() else @getPath()
+  @change: (event) ->
+    if @options.shim and event.state?.path?
+      path = event.state.path
+    else
+      path = if @getFragment() isnt '' then @getFragment() else @getPath()
     return if path is @path
     @path = path
     @matchRoute(@path)
@@ -98,19 +111,20 @@ class Spine.Route extends Spine.Module
   @matchRoute: (path, options) ->
     for route in @routes
       if route.match(path, options)
-        @trigger("change", route, path)
+        @trigger('change', route, path)
         return route
 
   constructor: (@path, @callback) ->
     @names = []
 
-    if typeof path is "string"
+    if typeof path is 'string'
+      namedParam.lastIndex = 0
       while (match = namedParam.exec(path)) != null
         @names.push(match[1])
         
-      path = path.replace(escapeRegExp, "\\$&")
-                 .replace(namedParam, "([^\/]*)")
-                 .replace(splatParam, "(.*?)")
+      path = path.replace(escapeRegExp, '\\$&')
+                 .replace(namedParam, '([^\/]*)')
+                 .replace(splatParam, '(.*?)')
                  
       @route = new RegExp('^' + path + '$')
     else


### PR DESCRIPTION
A we can see in the documentation shimming can be quite useful.

---

Sometimes it's convenient to use routes, without any changes to the page's URL or hash fragment. This is an especially common scenario in full-screen mobile or PhoneGap applications, where the page's address isn't even displayed. To cater for this, Route.setup() takes a shim option; for example:

`Spine.Route.setup(shim: true)`

---

When using it while developing a mobile website I noticed it breaks back button support, though. Therefore I made some small change to route.coffee to fix this issue. Using the following code will add history support for shimming.

`Spine.Route.setup(shim: true, history: true)`

Disclaimer: this will only work on browsers with pushState support
