### PR TITLE
Optionally supress event trigger on models using options hash

### DIFF
--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -15,6 +15,9 @@ Events =
 
   trigger: (args...) ->
     ev = args.shift()
+    
+    options = args[args.length-1]
+    return if typeof options is 'object' and options.silent
 
     list = @hasOwnProperty('_callbacks') and @_callbacks?[ev]
     return unless list


### PR DESCRIPTION
Based on the discussion in [this](https://github.com/maccman/spine/issues/28) issue, this commit allows users to use the `silent` option while calling methods on models to prevent events from being triggered automatically.

Usage example:

```
Task.create({name: 'abc'}, {validate: false, silent: true});
```
