### PR TITLE
Adding the ability to access globs by name in params object

### DIFF
--- a/src/route.coffee
+++ b/src/route.coffee
@@ -108,7 +108,11 @@ class Spine.Route extends Spine.Module
       namedParam.lastIndex = 0
       while (match = namedParam.exec(path)) != null
         @names.push(match[1])
-        
+
+      splatParam.lastIndex = 0
+      while (match = splatParam.exec(path)) != null
+        @names.push(match[1])
+  
       path = path.replace(escapeRegExp, '\\$&')
                  .replace(namedParam, '([^\/]*)')
                  .replace(splatParam, '(.*?)')


### PR DESCRIPTION
It was not possible to access a defined 'match all' glob in a route

@routes:
  "action/:action/*glob": (params) -> doStuff(params.glob)

was expecting to give the ability to access params.glob in the route callback

this patch (only mimicking the behavior setup for named params) allow this I hope
