### PR TITLE
Allow one to cleanly override the cid for custom IDs (similar to previous commit allowing override of guid()).

### DIFF
--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -224,15 +224,15 @@ class Model extends Module
 
   @idCounter: 0
 
-  @uid: ->
-    @idCounter++
+  @uid: (prefix='') ->
+    prefix + @idCounter++
 
   # Instance
 
   constructor: (atts) ->
     super
     @load atts if atts
-    @cid or= 'c-' + @constructor.uid()
+    @cid or= @constructor.uid('c-')
 
   isNew: ->
     not @exists()


### PR DESCRIPTION
Before CIDs there was a way to override the ID generation in Spine to create custom, client-side IDs.  This is still possible with the current version of Spine by overriding uid(), but each ID will have a "c-" prepended to it.  This small change makes it so that one can completely override how the CIDs are created including the CID prefix. 

This is very helpful for the app I'm building, otherwise I would need to override the entire constructor to get IDs in the right format. 
