### PR TITLE
Add @controllers variable to Spine.Controller

### DIFF
--- a/lib/spine.js
+++ b/lib/spine.js
@@ -357,14 +357,15 @@
 
     Model.idCounter = 0;
 
-    Model.uid = function() {
-      return this.idCounter++;
+    Model.uid = function(prefix) {
+      if (prefix == null) prefix = '';
+      return prefix + this.idCounter++;
     };
 
     function Model(atts) {
       Model.__super__.constructor.apply(this, arguments);
       if (atts) this.load(atts);
-      this.cid || (this.cid = 'c-' + this.constructor.uid());
+      this.cid || (this.cid = this.constructor.uid('c-'));
     }
 
     Model.prototype.isNew = function() {
@@ -598,6 +599,7 @@
       });
       if (!this.events) this.events = this.constructor.events;
       if (!this.elements) this.elements = this.constructor.elements;
+      this.controllers = [];
       if (this.events) this.delegateEvents(this.events);
       if (this.elements) this.refreshElements();
       Controller.__super__.constructor.apply(this, arguments);
@@ -649,19 +651,24 @@
     };
 
     Controller.prototype.html = function(element) {
+      this.controllers = [];
       this.el.html(element.el || element);
       this.refreshElements();
       return this.el;
     };
 
     Controller.prototype.append = function() {
-      var e, elements, _ref;
+      var e, elements, _i, _len, _ref;
       elements = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
+      for (_i = 0, _len = elements.length; _i < _len; _i++) {
+        e = elements[_i];
+        if (e.el) this.controllers.push(e);
+      }
       elements = (function() {
-        var _i, _len, _results;
+        var _j, _len2, _results;
         _results = [];
-        for (_i = 0, _len = elements.length; _i < _len; _i++) {
-          e = elements[_i];
+        for (_j = 0, _len2 = elements.length; _j < _len2; _j++) {
+          e = elements[_j];
           _results.push(e.el || e);
         }
         return _results;
@@ -672,19 +679,25 @@
     };
 
     Controller.prototype.appendTo = function(element) {
+      var _ref;
+      if (element.el) if ((_ref = element.controllers) != null) _ref.push(this);
       this.el.appendTo(element.el || element);
       this.refreshElements();
       return this.el;
     };
 
     Controller.prototype.prepend = function() {
-      var e, elements, _ref;
+      var e, elements, _i, _len, _ref;
       elements = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
+      for (_i = 0, _len = elements.length; _i < _len; _i++) {
+        e = elements[_i];
+        if (e.el) this.controllers.push(e);
+      }
       elements = (function() {
-        var _i, _len, _results;
+        var _j, _len2, _results;
         _results = [];
-        for (_i = 0, _len = elements.length; _i < _len; _i++) {
-          e = elements[_i];
+        for (_j = 0, _len2 = elements.length; _j < _len2; _j++) {
+          e = elements[_j];
           _results.push(e.el || e);
         }
         return _results;

--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -402,10 +402,10 @@ class Controller extends Module
 
     @events = @constructor.events unless @events
     @elements = @constructor.elements unless @elements
+    @controllers = []
 
     @delegateEvents(@events) if @events
     @refreshElements() if @elements
-
     super
 
   release: (callback) =>
@@ -438,22 +438,26 @@ class Controller extends Module
     setTimeout(@proxy(func), timeout || 0)
 
   html: (element) ->
+    @controllers = []
     @el.html(element.el or element)
     @refreshElements()
     @el
 
   append: (elements...) ->
+    @controllers.push(e) for e in elements when e.el
     elements = (e.el or e for e in elements)
     @el.append(elements...)
     @refreshElements()
     @el
 
   appendTo: (element) ->
+    element.controllers?.push(this) if element.el
     @el.appendTo(element.el or element)
     @refreshElements()
     @el
 
   prepend: (elements...) ->
+    @controllers.push(e) for e in elements when e.el
     elements = (e.el or e for e in elements)
     @el.prepend(elements...)
     @refreshElements()

--- a/test/specs/controller.js
+++ b/test/specs/controller.js
@@ -90,4 +90,51 @@ describe("Controller", function(){
     var users = new Users();
     expect(users.el.attr("style")).toEqual("width: 100%");
   });
+
+  it("saves controllers on append", function() {
+    AnotherController = Spine.Controller.sub()
+    var users = new Users();
+    var ac    = new AnotherController();
+    expect(users.controllers).toEqual([]);
+    users.append(ac);
+    expect(users.controllers.length).toEqual(1);
+    expect(users.controllers).toEqual([ac]);
+  });
+
+  it("saves controllers on prepend", function() {
+    AnotherController = Spine.Controller.sub()
+    var users = new Users();
+    var ac    = new AnotherController();
+    expect(users.controllers).toEqual([]);
+    users.prepend(ac);
+    expect(users.controllers.length).toEqual(1);
+    expect(users.controllers).toEqual([ac]);
+  });
+
+  it("does not save elements to controllers", function() {
+    var users = new Users();
+    expect(users.controllers).toEqual([]);
+    users.append($("<div></div>"));
+    expect(users.controllers).toEqual([]);
+  });
+
+  it("clears the controllers internal variable on an html call", function() {
+    AnotherController = Spine.Controller.sub()
+    var users = new Users();
+    var ac    = new AnotherController();
+    expect(users.controllers).toEqual([]);
+    users.append(ac);
+    expect(users.controllers).toEqual([ac]);
+    users.html("<div></div>");
+    expect(users.controllers).toEqual([]);
+  });
+
+  it("adds the controllers to the internals on an appendTo call", function() {
+    AnotherController = Spine.Controller.sub()
+    var users = new Users();
+    var ac    = new AnotherController();
+    expect(ac.controllers).toEqual([]);
+    users.appendTo(ac);
+    expect(ac.controllers).toEqual([users]);
+  });
 });


### PR DESCRIPTION
This change introduces the @controllers instance variable in Spine.Controller. This keeps track of any controllers that have been added to an existing controller during a call to append, prepend, or appendTo. This also resets the controllers variable when calling html.

The purpose of this is to remove the repetitive pattern of keeping track of controllers added yourself, for example in the element pattern.

I ran in to this when needing to keep track of several controllers I appended myself but needed access to the controller instance and not necessarily just the associated element.
