### PR TITLE
Adding the ability to Model.create() function to accept list as atts argument

### DIFF
--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -178,8 +178,10 @@ class Model extends Module
     @find(id).updateAttributes(atts, options)
 
   @create: (atts, options) ->
-    record = new @(atts)
-    record.save(options)
+    atts = if isArray(atts) then atts.slice() else [atts]
+    for att in atts
+      record = new @(att)
+      record.save(options)
 
   @destroy: (id, options) ->
     @find(id).destroy(options)

--- a/test/specs/model.js
+++ b/test/specs/model.js
@@ -10,6 +10,12 @@ describe("Model", function(){
     expect(Asset.first()).toEqual(asset);
   });
 
+  it("can create multiple records", function(){
+    var asset_list = [{name: "test.pdf"}, {name: "test1.pdf"}, {name: "test3.pdf"}],
+    asset = Asset.create(asset_list);
+    expect(Asset.count()).toEqual(3);
+  });
+
   it("can update records", function(){
     var asset = Asset.create({name: "test.pdf"});
 


### PR DESCRIPTION
Simple example:

cities = [{name: "Sofia"}, {name: "New York"}, {name: "Stara Zagora"}, {name: "San Francisco"}]
City.create(cities)
