### PR TITLE
fixed findAllByAttribute(name, value) to make sure it filters results by association

### DIFF
--- a/src/relation.coffee
+++ b/src/relation.coffee
@@ -25,7 +25,7 @@ class Collection extends Spine.Module
 
   findAllByAttribute: (name, value) ->
     @model.select (rec) =>
-      rec[name] is value
+      @associated(rec) and rec[name] is value
 
   findByAttribute: (name, value) ->
     @findAllByAttribute(name, value)[0]


### PR DESCRIPTION
findAllByAttribute(name, value) was returning all records, not just the ones in the current association.
