### PR TITLE
Allow Model::updateAttribute to update an attribute which is a function

### DIFF
--- a/lib/spine.js
+++ b/lib/spine.js
@@ -446,8 +446,10 @@
     };
 
     Model.prototype.updateAttribute = function(name, value, options) {
-      this[name] = value;
-      return this.save(options);
+      var atts;
+      atts = {};
+      atts[name] = value;
+      return this.updateAttributes(atts, options);
     };
 
     Model.prototype.updateAttributes = function(atts, options) {

--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -283,7 +283,7 @@ class Model extends Module
     record
 
   updateAttribute: (name, value, options) ->
-    atts = {}
+    atts       = {}
     atts[name] = value
     @updateAttributes(atts, options)
 


### PR DESCRIPTION
``` coffeescript
class Asset extends Spine.Model
  @configure 'Asset', 'name'
  name: (value) ->
    @name = value.toLowerCase()

foo = Asset.create(name: 'Foo.PDF')  # foo.name > 'foo.pdf'
```
## 

we can update `foo`'s `name` attribute which is a function:

``` coffeescript
foo.updateAttribute('name', 'Bar.PDF')  # foo.name > 'bar.pdf'
```

because `Model::updateAttribute` now relies on `Model::load` through `Model::updateAttributes`

NB: Also useful for updating relations, eg: `album.updateAttribute('photos', [###...###])`

Hope this makes sense,
Cheers
