### PR TITLE
fix idCounter and also weird .sort() bug

### DIFF
--- a/lib/spine.js
+++ b/lib/spine.js
@@ -101,8 +101,11 @@
       return this;
     };
 
-    Module.proxy = function() {
-      return this.prototype.proxy.apply(this, arguments);
+    Module.proxy = function(func) {
+      var _this = this;
+      return function() {
+        return func.apply(_this, arguments);
+      };
     };
 
     Module.prototype.proxy = function(func) {
@@ -363,16 +366,18 @@
         _results = [];
         for (_i = 0, _len = _ref.length; _i < _len; _i++) {
           model = _ref[_i];
-          _results.push(model.id);
+          _results.push(model.id.slice(this.prefix.length) * 1);
         }
         return _results;
-      }).call(this)).sort();
+      }).call(this)).sort(function(x, y) {
+        return x - y;
+      });
       return this.idCounter = (ids[ids.length - 1] || -1) + 1;
     };
 
     Model.uid = function(prefix) {
-      if (prefix == null) prefix = '';
-      return prefix + this.idCounter++;
+      this.prefix = prefix != null ? prefix : '';
+      return this.prefix + this.idCounter++;
     };
 
     function Model(atts) {

--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -227,11 +227,14 @@ class Model extends Module
   @idCounter: 0
 
   @resetIdCounter: ->
-    ids = (model.id for model in @all()).sort()
-    @idCounter = (ids[ids.length - 1] or -1) + 1
+    ids = (
+      for model in @all()
+        model.id[@prefix.length ..] * 1
+    ).sort((x, y) -> x - y)
+    @idCounter = (ids[ids.length - 1] or - 1) + 1
 
-  @uid: (prefix = '') ->
-    prefix + @idCounter++
+  @uid: (@prefix = '') ->
+    @prefix + @idCounter++
 
   # Instance
 


### PR DESCRIPTION
I'm not sure, why it's different the use of sort...

``` javascript
[1, 2, 3, 8, 12, 15].sort() = [1, 12, 15, 2, 3, 8]

[1, 2, 3, 8, 12, 15].sort(function(x, y){return x-y}) = [1, 2, 3, 8, 12, 15]
```
