### PR TITLE
Change the behavior of refresh so that it always passes the refreshed models

### DIFF
--- a/lib/ajax.js
+++ b/lib/ajax.js
@@ -1,9 +1,6 @@
 (function() {
-  var $, Ajax, Base, Collection, Extend, Include, Model, Singleton,
-    __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; },
-    __hasProp = Object.prototype.hasOwnProperty,
-    __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; },
-    __slice = Array.prototype.slice;
+  var $, Ajax, Base, Collection, Extend, Include, Model, Singleton;
+  var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; }, __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; }, __slice = Array.prototype.slice;
 
   if (typeof Spine === "undefined" || Spine === null) Spine = require('spine');
 
@@ -79,9 +76,9 @@
 
   })();
 
-  Collection = (function(_super) {
+  Collection = (function() {
 
-    __extends(Collection, _super);
+    __extends(Collection, Base);
 
     function Collection(model) {
       this.model = model;
@@ -108,8 +105,8 @@
     };
 
     Collection.prototype.fetch = function(params, options) {
-      var id,
-        _this = this;
+      var id;
+      var _this = this;
       if (params == null) params = {};
       if (options == null) options = {};
       if (id = params.id) {
@@ -134,11 +131,11 @@
 
     return Collection;
 
-  })(Base);
+  })();
 
-  Singleton = (function(_super) {
+  Singleton = (function() {
 
-    __extends(Singleton, _super);
+    __extends(Singleton, Base);
 
     function Singleton(record) {
       this.record = record;
@@ -224,7 +221,7 @@
 
     return Singleton;
 
-  })(Base);
+  })();
 
   Model.host = '';
 

--- a/lib/list.js
+++ b/lib/list.js
@@ -1,16 +1,14 @@
 (function() {
-  var $,
-    __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; },
-    __hasProp = Object.prototype.hasOwnProperty,
-    __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; };
+  var $;
+  var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; }, __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; };
 
   if (typeof Spine === "undefined" || Spine === null) Spine = require('spine');
 
   $ = Spine.$;
 
-  Spine.List = (function(_super) {
+  Spine.List = (function() {
 
-    __extends(List, _super);
+    __extends(List, Spine.Controller);
 
     List.prototype.events = {
       'click .item': 'click'
@@ -61,7 +59,7 @@
 
     return List;
 
-  })(Spine.Controller);
+  })();
 
   if (typeof module !== "undefined" && module !== null) {
     module.exports = Spine.List;

--- a/lib/local.js
+++ b/lib/local.js
@@ -1,4 +1,3 @@
-(function() {
 
   if (typeof Spine === "undefined" || Spine === null) Spine = require('spine');
 
@@ -24,5 +23,3 @@
   if (typeof module !== "undefined" && module !== null) {
     module.exports = Spine.Model.Local;
   }
-
-}).call(this);

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -1,16 +1,14 @@
 (function() {
-  var $,
-    __hasProp = Object.prototype.hasOwnProperty,
-    __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; },
-    __slice = Array.prototype.slice;
+  var $;
+  var __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; }, __slice = Array.prototype.slice;
 
   if (typeof Spine === "undefined" || Spine === null) Spine = require('spine');
 
   $ = Spine.$;
 
-  Spine.Manager = (function(_super) {
+  Spine.Manager = (function() {
 
-    __extends(Manager, _super);
+    __extends(Manager, Spine.Module);
 
     Manager.include(Spine.Events);
 
@@ -66,7 +64,7 @@
 
     return Manager;
 
-  })(Spine.Module);
+  })();
 
   Spine.Controller.include({
     active: function() {
@@ -93,9 +91,9 @@
     }
   });
 
-  Spine.Stack = (function(_super) {
+  Spine.Stack = (function() {
 
-    __extends(Stack, _super);
+    __extends(Stack, Spine.Controller);
 
     Stack.prototype.controllers = {};
 
@@ -104,8 +102,8 @@
     Stack.prototype.className = 'spine stack';
 
     function Stack() {
-      var key, value, _fn, _ref, _ref2,
-        _this = this;
+      var key, value, _fn, _ref, _ref2;
+      var _this = this;
       Stack.__super__.constructor.apply(this, arguments);
       this.manager = new Spine.Manager;
       _ref = this.controllers;
@@ -140,7 +138,7 @@
 
     return Stack;
 
-  })(Spine.Controller);
+  })();
 
   if (typeof module !== "undefined" && module !== null) {
     module.exports = Spine.Manager;

--- a/lib/relation.js
+++ b/lib/relation.js
@@ -1,7 +1,6 @@
 (function() {
-  var Collection, Instance, Singleton, Spine, isArray, require, singularize, underscore,
-    __hasProp = Object.prototype.hasOwnProperty,
-    __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; };
+  var Collection, Instance, Singleton, Spine, isArray, require, singularize, underscore;
+  var __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; };
 
   Spine = this.Spine || require('spine');
 
@@ -11,9 +10,9 @@
     return eval(value);
   });
 
-  Collection = (function(_super) {
+  Collection = (function() {
 
-    __extends(Collection, _super);
+    __extends(Collection, Spine.Module);
 
     function Collection(options) {
       var key, value;
@@ -42,8 +41,8 @@
     };
 
     Collection.prototype.find = function(id) {
-      var records,
-        _this = this;
+      var records;
+      var _this = this;
       records = this.select(function(rec) {
         return rec.id + '' === id + '';
       });
@@ -98,11 +97,11 @@
 
     return Collection;
 
-  })(Spine.Module);
+  })();
 
-  Instance = (function(_super) {
+  Instance = (function() {
 
-    __extends(Instance, _super);
+    __extends(Instance, Spine.Module);
 
     function Instance(options) {
       var key, value;
@@ -125,11 +124,11 @@
 
     return Instance;
 
-  })(Spine.Module);
+  })();
 
-  Singleton = (function(_super) {
+  Singleton = (function() {
 
-    __extends(Singleton, _super);
+    __extends(Singleton, Spine.Module);
 
     function Singleton(options) {
       var key, value;
@@ -152,7 +151,7 @@
 
     return Singleton;
 
-  })(Spine.Module);
+  })();
 
   singularize = function(str) {
     return str.replace(/s$/, '');

--- a/lib/route.js
+++ b/lib/route.js
@@ -1,8 +1,6 @@
 (function() {
-  var $, escapeRegExp, hashStrip, namedParam, splatParam,
-    __hasProp = Object.prototype.hasOwnProperty,
-    __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; },
-    __slice = Array.prototype.slice;
+  var $, escapeRegExp, hashStrip, namedParam, splatParam;
+  var __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; }, __slice = Array.prototype.slice;
 
   if (typeof Spine === "undefined" || Spine === null) Spine = require('spine');
 
@@ -16,10 +14,10 @@
 
   escapeRegExp = /[-[\]{}()+?.,\\^$|#\s]/g;
 
-  Spine.Route = (function(_super) {
+  Spine.Route = (function() {
     var _ref;
 
-    __extends(Route, _super);
+    __extends(Route, Spine.Module);
 
     Route.extend(Spine.Events);
 
@@ -168,7 +166,7 @@
 
     return Route;
 
-  })(Spine.Module);
+  })();
 
   Spine.Route.change = Spine.Route.proxy(Spine.Route.change);
 

--- a/lib/spine.js
+++ b/lib/spine.js
@@ -1,10 +1,6 @@
 (function() {
-  var $, Controller, Events, Log, Model, Module, Spine, isArray, isBlank, makeArray, moduleKeywords,
-    __slice = Array.prototype.slice,
-    __indexOf = Array.prototype.indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; },
-    __hasProp = Object.prototype.hasOwnProperty,
-    __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; },
-    __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
+  var $, Controller, Events, Log, Model, Module, Spine, isArray, isBlank, makeArray, moduleKeywords;
+  var __slice = Array.prototype.slice, __hasProp = Object.prototype.hasOwnProperty, __indexOf = Array.prototype.indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (__hasProp.call(this, i) && this[i] === item) return i; } return -1; }, __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype; return child; }, __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
 
   Events = {
     bind: function(ev, callback) {
@@ -123,9 +119,9 @@
 
   })();
 
-  Model = (function(_super) {
+  Model = (function() {
 
-    __extends(Model, _super);
+    __extends(Model, Module);
 
     Model.extend(Events);
 
@@ -191,7 +187,7 @@
         this.crecords[record.cid] = record;
       }
       this.resetIdCounter();
-      this.trigger('refresh', !options.clear && this.cloneArray(records));
+      this.trigger('refresh', this.cloneArray(records));
       return this;
     };
 
@@ -552,8 +548,8 @@
     };
 
     Model.prototype.bind = function(events, callback) {
-      var binder, unbinder,
-        _this = this;
+      var binder, unbinder;
+      var _this = this;
       this.constructor.bind(events, binder = function(record) {
         if (record && _this.eql(record)) return callback.apply(_this, arguments);
       });
@@ -567,8 +563,8 @@
     };
 
     Model.prototype.one = function(events, callback) {
-      var binder,
-        _this = this;
+      var binder;
+      var _this = this;
       return binder = this.bind(events, function() {
         _this.constructor.unbind(events, binder);
         return callback.apply(_this);
@@ -588,11 +584,11 @@
 
     return Model;
 
-  })(Module);
+  })();
 
-  Controller = (function(_super) {
+  Controller = (function() {
 
-    __extends(Controller, _super);
+    __extends(Controller, Module);
 
     Controller.include(Events);
 
@@ -727,7 +723,7 @@
 
     return Controller;
 
-  })(Module);
+  })();
 
   $ = (typeof window !== "undefined" && window !== null ? window.jQuery : void 0) || (typeof window !== "undefined" && window !== null ? window.Zepto : void 0) || function(element) {
     return element;
@@ -785,9 +781,9 @@
 
   Module.create = Module.sub = Controller.create = Controller.sub = Model.sub = function(instances, statics) {
     var result;
-    result = (function(_super) {
+    result = (function() {
 
-      __extends(result, _super);
+      __extends(result, this);
 
       function result() {
         result.__super__.constructor.apply(this, arguments);
@@ -795,7 +791,7 @@
 
       return result;
 
-    })(this);
+    }).call(this);
     if (instances) result.include(instances);
     if (statics) result.extend(statics);
     if (typeof result.unbind === "function") result.unbind();
@@ -805,9 +801,9 @@
   Model.setup = function(name, attributes) {
     var Instance;
     if (attributes == null) attributes = [];
-    Instance = (function(_super) {
+    Instance = (function() {
 
-      __extends(Instance, _super);
+      __extends(Instance, this);
 
       function Instance() {
         Instance.__super__.constructor.apply(this, arguments);
@@ -815,7 +811,7 @@
 
       return Instance;
 
-    })(this);
+    }).call(this);
     Instance.configure.apply(Instance, [name].concat(__slice.call(attributes)));
     return Instance;
   };

--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -132,7 +132,7 @@ class Model extends Module
 
     @resetIdCounter()
 
-    @trigger('refresh', not options.clear and @cloneArray(records))
+    @trigger('refresh', @cloneArray(records))
     this
 
   @select: (callback) ->

--- a/test/specs/model.js
+++ b/test/specs/model.js
@@ -411,6 +411,14 @@ describe("Model", function(){
       asset.updateAttributes({name: "lonely heart.png"});
     });
 
+    it("should pass refreshed records with refresh event", function(){
+      Asset.bind("refresh", function(assets){
+        expect(assets[0].name).toBe("cartoon world.png")
+      });
+
+      Asset.refresh([{name: "cartoon world.png"}]);
+    });
+
     it("should be able to unbind instance events", function(){
       var asset = Asset.create({name: "cartoon world.png"});
 


### PR DESCRIPTION
I'm submitting this patch to change the refresh method so that it always passes the refreshed models.  For some reason when {clear: true} is passed the 'refresh' event is triggered with false.  Is there a use case for this?  I think most would expect the refreshed models to always be passed along no matter what "clear" is set to.

If someone needs to know whether "clear" was set when binding to the 'refresh' event, it would make more sense to me to add an options object to the trigger.  Here is my current use case is for the attribute tracking extension that I made which should show the problem that I'm running into:

```
AttributeTracking =
  extended: ->
    @oldAttributes = {}

    @bind 'refresh create', (models) =>
      # Spine's behavior for refresh with {clear: true} passes false so we need
      # this fix.
      models or= @all()

      # models could be an array of models or one model.
      if models.length?
        @setOldAttributes(model) for model in models
      else
        @setOldAttributes(models)
```
