### PR TITLE
Make functions defined in events: {} to be called in correct context

### DIFF
--- a/lib/spine.js
+++ b/lib/spine.js
@@ -724,17 +724,17 @@
       _results = [];
       for (key in events) {
         method = events[key];
-        if (typeof method !== 'function') {
+        if (typeof method === 'function') {
           method = (function(method) {
             return function() {
-              _this[method].apply(_this, arguments);
+              method.apply(_this, arguments);
               return true;
             };
           })(method);
         } else {
           method = (function(method) {
             return function() {
-              method.apply(_this, arguments);
+              _this[method].apply(_this, arguments);
               return true;
             };
           })(method);

--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -425,14 +425,14 @@ class Controller extends Module
   delegateEvents: (events) ->
     for key, method of events
 
-      unless typeof(method) is 'function'
+      if typeof(method) is 'function'
         # Always return true from event handlers
         method = do (method) => =>
-          @[method].apply(this, arguments)
+          method.apply(this, arguments)
           true
       else
         method = do (method) => =>
-          method.apply(this, arguments)
+          @[method].apply(this, arguments)
           true
 
       match      = key.match(@eventSplitter)


### PR DESCRIPTION
When functions is defined in controllers events {} it should be called in the context of the controller. 

This commit makes the functions this point to the controller
