### PR TITLE
Dirty plugin for SpineJS. 

### DIFF
--- a/lib/dirty.js
+++ b/lib/dirty.js
@@ -1,0 +1,38 @@
+(function() {
+  var Include;
+    if (typeof Spine !== "undefined" && Spine !== null) {
+    Spine;
+  } else {
+    Spine = require('spine');
+  };
+  Include = {
+    savePrevious: function() {
+      return this.constructor.records[this.id].previousAttributes = this.attributes();
+    }
+  };
+  Spine.Model.Dirty = {
+    extended: function() {
+      this.bind('refresh', function() {
+        return this.each(function(record) {
+          return record.savePrevious();
+        });
+      });
+      this.bind('save', function(record) {
+        var key, _i, _len, _ref;
+        if (record.previousAttributes != null) {
+          _ref = record.constructor.attributes;
+          for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+            key = _ref[_i];
+            if (key in record) {
+              if (record[key] !== record.previousAttributes[key]) {
+                record.trigger('change:' + key, record[key]);
+              }
+            }
+          }
+        }
+        return record.savePrevious();
+      });
+      return this.include(Include);
+    }
+  };
+}).call(this);

--- a/src/dirty.coffee
+++ b/src/dirty.coffee
@@ -1,0 +1,19 @@
+Spine ?= require('spine')
+
+Include =
+  savePrevious: ->
+    @constructor.records[@id].previousAttributes = @attributes()
+
+Spine.Model.Dirty =
+  extended: ->
+    @bind 'refresh', ->
+      @each (record) -> record.savePrevious()
+
+    @bind 'save', (record) ->
+      if record.previousAttributes?
+        for key in record.constructor.attributes when key of record
+          if record[key] isnt record.previousAttributes[key]
+            record.trigger('change:'+key, record[key])
+      record.savePrevious()
+
+    @include Include

--- a/test/index.html
+++ b/test/index.html
@@ -10,12 +10,14 @@
   <script src="../lib/spine.js" type="text/javascript" charset="utf-8"></script>
   <script src="../lib/local.js" type="text/javascript" charset="utf-8"></script>
   <script src="../lib/relation.js" type="text/javascript" charset="utf-8"></script>
+  <script src="../lib/dirty.js" type="text/javascript" charset="utf-8"></script>
   
   <script src="specs/class.js" type="text/javascript" charset="utf-8"></script>
   <script src="specs/events.js" type="text/javascript" charset="utf-8"></script>
   <script src="specs/model.js" type="text/javascript" charset="utf-8"></script>
   <script src="specs/model.local.js" type="text/javascript" charset="utf-8"></script>
   <script src="specs/model.relation.js" type="text/javascript" charset="utf-8"></script>
+  <script src="specs/model.dirty.js" type="text/javascript" charset="utf-8"></script>
   <script src="specs/controller.js" type="text/javascript" charset="utf-8"></script>
 </head>
 <body>

--- a/test/specs/model.dirty.js
+++ b/test/specs/model.dirty.js
@@ -1,0 +1,30 @@
+describe("Model.Dirty", function() {
+  var user;
+  var spy;
+
+  beforeEach(function() {
+    var User = Spine.Model.setup("User", ["name", "emails"]);
+    User.extend(Spine.Model.Dirty);
+    user = User.create({name: "Dingding", emails: ["yedingding@gmail.com"]});
+    var noop = {spy: function(){}};
+    spyOn(noop, "spy");
+    spy = noop.spy;
+  });
+
+  it("should have previousAttributes", function() {
+    expect(user.previousAttributes.name).toEqual("Dingding");
+    expect(user.previousAttributes.emails).toEqual(["yedingding@gmail.com"]);
+  });
+
+  it("should trigger the change:name event", function() {
+    user.bind("change:name", spy);
+    user.updateAttribute("name", "Bob");
+    expect(spy).toHaveBeenCalledWith(user, "Bob");
+  });
+
+  it("should trigger the change:emails event", function() {
+    user.bind("change:emails", spy);
+    user.updateAttribute("emails", ["bob@gmail.com"]);
+    expect(spy).toHaveBeenCalledWith(user, ["bob@gmail.com"]);
+  });
+});

--- a/test/specs/model.local.js
+++ b/test/specs/model.local.js
@@ -30,7 +30,7 @@ describe("Model.Local", function(){
       {name: "Bob", id: "c-3"},
       {name: "Bob", id: "c-2"}
     ]);
-    expect(User.idCounter).toEqual(3);
+    expect(User.idCounter).toEqual(4);
   });
 
   it("should work with a blank refresh", function(){


### PR DESCRIPTION
So the model object can bind the event "change:#{field} to trigger event when the field value is changed.

By default it's off and if need this feature, the model should extend Spine.Model.Dirty.

A sample case.

``` javascript
class User extends Spine.Model
  @extend Spine.Model.Dirty
end
```
