### PR TITLE
Prevent calling uid twice in Spine.Model, by setting cid in attributes before constructing item

### DIFF
--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -232,7 +232,7 @@ class Model extends Module
   constructor: (atts) ->
     super
     @load atts if atts
-    @cid = @constructor.uid('c-')
+    @cid or= @constructor.uid('c-')
 
   isNew: ->
     not @exists()
@@ -302,12 +302,12 @@ class Model extends Module
     this
 
   dup: (newRecord) ->
-    result = new @constructor(@attributes())
+    newAtts = @attributes()
     if newRecord is false
-      result.cid = @cid
+      newAtts.cid = @cid
     else
-      delete result.id
-    result
+      delete newAtts.id
+    new @constructor(newAtts)
 
   clone: ->
     createObject(@)


### PR DESCRIPTION
Currently:

A newly created item receives a new `cid`.

Then in `dup`, `attributes()` doesn't specify a `cid`, therefore when `constructor` is called (this is now the second time), `cid` can't be read from attributes.
I'm guessing the `or=` was removed because it was never called: `newrecord` is false, so a new `cid` is always created and taken instead of the original.

I believe the best fix is to swap in `cid` and out `id` _before_ the duplicate is created.
