### PR TITLE
Make it possible to overwrite client id prefix; also enables catching duplicate ids & cids

### DIFF
--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -224,7 +224,7 @@ class Model extends Module
 
   @idCounter: 0
 
-  @uid: (prefix = '') ->
+  @uid: (prefix = 'c-') ->
     prefix + @idCounter++
 
   # Instance
@@ -232,7 +232,7 @@ class Model extends Module
   constructor: (atts) ->
     super
     @load atts if atts
-    @cid or= @constructor.uid('c-')
+    @cid or= @constructor.uid()
 
   isNew: ->
     not @exists()


### PR DESCRIPTION
Currently, uid can never detect id or cid collisions because it has no idea of the prefix set for cid.

I believe because uid is only called in one place, the prefix should be set at uid.  Then uid can be overridden to provide a custom prefix and also to detect collisions.  Therefore it will be a truly "unique id".

I discovered this problem when extending the model to use local storage.

For example:

Using Spine.Model.Local
say Local has ids `c-1`
`fetch()` then will end up assigning `cid c-0` to item with `id c-1`

Then in create...

...create new `id`, will have `cid c-1`, which is then set as `id`...

```
@id          = @cid unless @id
```

...and then overwrites the old record...

```
@constructor.records[@id]   = record
@constructor.crecords[@cid] = record
```

...this is further finalized when saving.
