### PR TITLE
`Route.unbind()` is irrelevant if `shim: true`

### DIFF
--- a/src/route.coffee
+++ b/src/route.coffee
@@ -39,6 +39,8 @@ class Spine.Route extends Spine.Module
     @change()
 
   @unbind: ->
+    return if @options.shim
+
     if @history
       $(window).unbind('popstate', @change)
     else


### PR DESCRIPTION
since it should not have been bound in `Route.setup`
