### PR TITLE
Consolidating Spine.Route tests suite.

### DIFF
--- a/test/specs/route.js
+++ b/test/specs/route.js
@@ -1,102 +1,308 @@
-describe("Routing", function(){
-  var Route = Spine.Route;
-  var spy;
+describe("Routing", function () {
+  var Route = Spine.Route,
+      RouteOptions = Route.options,
+      spy;
 
-  var navigate = function(str, callback){
-    window.location.hash = str;
-    waits(50);
-    if (callback) { runs(callback); }
+  // http://coffeescript.org/#try:navigate%20%3D%20(args...)%20-%3E%0A%20%20newPath%20%3D%20undefined%0A%20%20%24.Deferred((dfd)%20-%3E%0A%20%20%20%20Route.one%20'change'%2C%20(route%2C%20path)%20-%3E%20newPath%20%3D%20path%0A%0A%20%20%20%20Route.navigate%20args...%0A%0A%20%20%20%20waitsFor(-%3E%20newPath%3F)%0A%20%20%20%20runs(-%3E%20dfd.resolveWith(null%2C%20newPath))%0A%20%20).promise()
+  function navigate() {
+    var args = 1 <= arguments.length ? [].slice.call(arguments, 0) : [],
+        changed = false;
+
+    return $.Deferred(function(dfd) {
+      Route.one('change', function() {changed = true;});
+
+      Route.navigate.apply(Route, args);
+
+      waitsFor(function() {return changed === true;});
+      runs(function () {dfd.resolve()});
+    }).promise();
   };
 
-  beforeEach(function(){
-    Route.setup();
+  // Set (default REset) document's URL
+  var setUrl = (function () {
+    var originalTitle,
+        originalPath = window.location.pathname + window.location.search;
 
-    var noop = {spy: function(){}};
-    spyOn(noop, "spy");
-    spy = noop.spy;
+    return function (url) {
+      window.history.replaceState(null, originalTitle, url || originalPath);
+    };
+  }());
 
-    Route.history = false;
-    Route.routes  = [];
+  beforeEach(function () {
+    Route.options = RouteOptions; // Reset default Route options
   });
 
-  afterEach(function(){
+  afterEach(function () {
     Route.unbind();
-    window.location.hash = "";
+    Route.routes = [];
+    delete Route.path;
   });
 
-  it("can can navigate", function(){
-    Route.navigate("/users/1");
-    expect(window.location.hash).toEqual("#/users/1");
 
-    Route.navigate("/users", 2);
-    expect(window.location.hash).toEqual("#/users/2");
+  it("should have default options", function () {
+    expect(Route.options).toEqual({
+      trigger: true,
+      history: false,
+      shim: false
+    });
   });
 
-  it("can add regex route", function(){
-    Route.add(/\/users\/(\d+)/);
-    expect(Route.routes).toBeTruthy();
+
+  describe('With shim', function () {
+    beforeEach(function () {
+      Route.setup({shim: true});
+    });
+
+
+    it("should not have bound any hashchange|popstate event to window", function () {
+      var events = $(window).data('events') || {};
+
+      expect('hashchange' in events || 'popstate' in events).toBe(false);
+    });
+
+
+    it("can set its path", function () {
+      expect(Route.path).toBeUndefined()
+
+      Route.change();
+
+      // Don't check the path is valid but just set to something -> check this for hashes and history
+      expect(Route.path).toBeDefined();
+    });
+
+
+    it("can add a single route", function () {
+      Route.add('/foo');
+
+      expect(Route.routes.length).toBe(1);
+    });
+
+
+    it("can add a bunch of routes", function () {
+      Route.add({
+        '/foo': function () {},
+        '/bar': function () {}
+      });
+
+      expect(Route.routes.length).toBe(2);
+    });
+
+
+    it("can add regex route", function () {
+      Route.add(/\/users\/(\d+)/);
+
+      expect(Route.routes.length).toBe(1);
+    });
+
+
+    it("should trigger 'change' when a route matches", function () {
+      var changed = 0;
+      Route.one('change', function () {changed += 1;});
+      Route.add("/foo", function () {});
+
+      Route.navigate('/foo');
+
+      waitsFor(function () {return changed > 0;})
+      runs(function () {
+        expect(changed).toBe(1);
+      })
+    });
+
+
+    it("can navigate to path", function () {
+      Route.add("/users", function () {});
+
+      navigate("/users").done(function () {
+        expect(Route.path).toBe("/users");
+      });
+    });
+
+
+    it("can navigate to a path splitted into several arguments", function () {
+      Route.add("/users/1/2", function () {});
+
+      navigate("/users", 1, 2).done(function () {
+        expect(Route.path).toBe("/users/1/2");
+      });
+    });
+
+
+    describe('With spy', function () {
+      beforeEach(function () {
+        var noop = {spy: function () {}};
+        spyOn(noop, "spy");
+        spy = noop.spy;
+      });
+
+
+      it("should trigger 'navigate' when navigating", function () {
+        Route.one('navigate', spy);
+        Route.add("/foo", function () {});
+
+        Route.navigate('/foo');
+
+        expect(spy).toHaveBeenCalled();
+      });
+
+
+      it("should not navigate to the same path as the current", function () {
+        Route.one('navigate', spy);
+        Route.add("/foo", function () {});
+        Route.path = '/foo';
+
+        Route.navigate('/foo');
+
+        expect(spy).not.toHaveBeenCalled();
+        expect(Route.path).toBe('/foo');
+      });
+
+
+      it("can call routes when navigating", function () {
+        Route.add("/foo", spy);
+
+        navigate('/foo').done(function () {
+          expect(spy).toHaveBeenCalled();
+        });
+      });
+
+
+      it("can call routes with params", function () {
+        Route.add({"/users/:id/:id2": spy});
+
+        navigate('/users/1/2').done(function () {
+          expect(JSON.stringify(spy.mostRecentCall.args)).toBe(JSON.stringify([{
+            trigger: true,
+            history: false,
+            shim: true,
+            match: ["/users/1/2", "1", "2"], id: "1", id2: "2"
+          }]));
+        });
+      });
+
+
+      it("can call routes with glob", function () {
+        Route.add({"/page/*stuff": spy});
+
+        navigate("/page/gah").done(function () {
+          expect(JSON.stringify(spy.mostRecentCall.args)).toBe(JSON.stringify([{
+            trigger: true,
+            history: false,
+            shim: true,
+            match: ["/page/gah", "gah"], stuff: "gah"
+          }]));
+        });
+      });
+
+
+      it("can override trigger behavior when navigating", function () {
+        expect(Route.options.trigger).toBe(true);
+
+        Route.one('change', spy)
+
+        Route.add("/users", function () {});
+
+        Route.navigate('/users', false);
+        waits(50);
+        runs(function () {
+          expect(Route.options.trigger).toBe(true);
+          expect(spy).not.toHaveBeenCalled();
+        });
+      });
+
+    });
+
   });
 
-  it("can trigger routes", function(){
-     Route.add({
-       "/users":  $.proxy(spy, jasmine),
-       "/groups": $.proxy(spy, jasmine)
-     });
 
-     navigate("/users", function(){
-       expect(spy).toHaveBeenCalled();
-     });
+  describe('With hashes', function () {
+    beforeEach(function () {
+      Route.setup();
+    });
 
-     navigate("/groups", function(){
-       expect(spy).toHaveBeenCalled();
-     });
-   });
+    afterEach(function () {
+      setUrl();
+    });
 
-   it("can call routes with params", function(){
-     Route.add({
-       "/users/:id/:id2": spy
-     });
 
-     navigate("/users/1/2", function(){
-       expect(spy).toHaveBeenCalledWith([{match: ["/users/1/2", "1", "2"], id: "1", id2: "2"}]);
-     });
-   });
+    it("should have bound 'hashchange' event to window", function () {
+      var events = $(window).data('events') || {};
 
-   it("can call routes with glob", function(){
-     Route.add({
-       "/page/*stuff": spy
-     });
+      expect('hashchange' in events).toBe(true);
+    });
 
-     navigate("/page/gah", function(){
-       expect(spy.mostRecentCall.args).toEqual([{match: ["/page/gah", "gah"]}]);
-     });
-   });
 
-   it("should trigger routes when navigating", function(){
-     Route.add({
-       "/users/:id": spy
-     });
+    it("should unbind", function () {
+      Route.unbind();
+      var events = $(window).data('events') || {};
 
-     Route.navigate("/users/1");
+      expect('hashchange' in events).toBe(false);
+    });
 
-     waits(50);
 
-     runs(function(){
-       expect(spy).toHaveBeenCalled();
-     });
-   });
+    it("can set its path", function () {
+      delete Route.path // Remove path which has been set by @setup > @change
 
-   it("has option to trigger routes when navigating", function(){
-     Route.add({
-       "/users/:id": spy
-     });
+      window.location.hash = "#/foo"
+      Route.change();
 
-     Route.navigate("/users/1", true);
+      expect(Route.path).toBe('/foo');
+    });
 
-     waits(50);
 
-     runs(function(){
-       expect(spy).toHaveBeenCalled();
-     });
-   });
+    it("can navigate", function () {
+      Route.add("/users/1", function () {});
+
+      navigate("/users", 1).done(function () {
+        expect(window.location.hash).toBe("#/users/1");
+      });
+    });
+
+  });
+
+
+  describe('With History API', function () {
+    beforeEach(function () {
+      Route.setup({history: true});
+    });
+
+    afterEach(function () {
+      setUrl();
+    });
+
+
+    it("should have bound 'popstate' event to window", function () {
+      var events = $(window).data('events') || {};
+
+      expect('popstate' in events).toBe(true);
+    });
+
+
+    it("should unbind", function () {
+      Route.unbind();
+      var events = $(window).data('events') || {};
+
+      expect('popstate' in events).toBe(false);
+    });
+
+
+    it("can set its path", function () {
+      delete Route.path // Remove path which has been set by @setup > @change
+
+      setUrl('/foo');
+      Route.change();
+
+      expect(Route.path).toBe('/foo');
+    });
+
+
+    it("can navigate", function () {
+      Route.add("/users/1", function () {});
+
+      navigate("/users/1").done(function () {
+        expect(window.location.pathname).toBe("/users/1");
+      });
+    });
+
+  });
+
 });


### PR DESCRIPTION
This fixes 2 broken specs and aims at addressing some reported routing related issues where it was not possible to correctly test them.

I've refactored the tests suites in order to be able to test hashes and history based routing separately.

The suite now consists of 23 specs (7 before) separated into 3 main specs:
- with shim (independent of `history` value)
- with hashes (`history:false`)
- with history (`history:true`)

I let you review it.

Cheers.
