### PR TITLE
Fix for #219

### DIFF
--- a/lib/spine.js
+++ b/lib/spine.js
@@ -500,7 +500,7 @@
       for (key in this) {
         if (!__hasProp.call(this, key)) continue;
         value = this[key];
-        if (this.attributes()[key] != null) {
+        if (this.constructor.attributes.indexOf(key) > -1) {
           delete this[key];
         }
       }

--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -282,7 +282,7 @@ class Model extends Module
   stripCloneAttrs: ->
     return if @hasOwnProperty 'cid' # Make sure it's not the raw object
     for own key, value of @
-      delete @[key] if @attributes()[key]?
+      delete @[key] if @constructor.attributes.indexOf(key) > -1
     this
 
   updateAttribute: (name, value, options) ->


### PR DESCRIPTION
This deletes a clone's own attributes after each `save()` to make sure it always links to the raw object's values.
