### PR TITLE
Fix spine.coffee to pass CoffeeLint class name rule

### DIFF
--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -521,11 +521,11 @@ Module.extend.call(Spine, Events)
 Module.create = Module.sub =
   Controller.create = Controller.sub =
     Model.sub = (instances, statics) ->
-      class result extends this
-      result.include(instances) if instances
-      result.extend(statics) if statics
-      result.unbind?()
-      result
+      class Result extends this
+      Result.include(instances) if instances
+      Result.extend(statics) if statics
+      Result.unbind?()
+      Result
 
 Model.setup = (name, attributes = []) ->
   class Instance extends this


### PR DESCRIPTION
The fix is desirable to those who checks their sources with CoffeeLint (or smth similar) as class names are usually CamelCased.
