### PR TITLE
Improve error log message when a model record isn't found

### DIFF
--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -103,12 +103,12 @@ class Model extends Module
     record = @records[id]
     if !record and ("#{id}").match(/c-\d+/)
       return @findCID(id)
-    throw new Error('Unknown record') unless record
+    throw new Error("No #{@className} record found for ID: #{id}") unless record
     record.clone()
 
   @findCID: (cid) ->
     record = @crecords[cid]
-    throw new Error('Unknown record') unless record
+    throw new Error("No #{@className} record found for CID: #{cid}") unless record
     record.clone()
 
   @exists: (id) ->


### PR DESCRIPTION
I've found it tough to track down which finds are causing problems when my code is minified. Better error messages helps, so I improved these error messages.
