### PR TITLE
Expose the classes in relation.coffee so that they can be extended

### DIFF
--- a/lib/relation.js
+++ b/lib/relation.js
@@ -252,4 +252,10 @@
     }
   });
 
+  Spine.Collection = Collection;
+
+  Spine.Singleton = Singleton;
+
+  Spine.Instance = Instance;
+
 }).call(this);

--- a/src/relation.coffee
+++ b/src/relation.coffee
@@ -142,3 +142,7 @@ Spine.Model.extend
     @::[name] = (value) ->
       association(@).update(value) if value?
       association(@).find()
+	  
+Spine.Collection = Collection
+Spine.Singleton = Singleton
+Spine.Instance = Instance


### PR DESCRIPTION
We have found it quite useful to be able to extend the classes in relation.coffee to add some additional functionality to them. It would be handy if the ability to do this was included by default.

This pull request simply exposes the relation classes as follows:

``` javascript
Spine.Collection = Collection
Spine.Singleton = Singleton
Spine.Instance = Instance
```
