### PR TITLE
on/off aliases for Events

### DIFF
--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -45,6 +45,9 @@ Events =
         break
     this
 
+Events.on = Events.bind
+Events.off = Events.unbind
+
 Log =
   trace: true
 


### PR DESCRIPTION
It seems a common pattern to have on/off as shorthand aliases for bind/unbind and it was weird for me not to see this common thing in Spine. Would be awesome to have them.
