### PR TITLE
Allow options to be passed into Collection.create()

### DIFF
--- a/lib/relation.js
+++ b/lib/relation.js
@@ -94,9 +94,9 @@
       return this.model.trigger('refresh', this.model.cloneArray(records));
     };
 
-    Collection.prototype.create = function(record) {
+    Collection.prototype.create = function(record, options) {
       record[this.fkey] = this.record.id;
-      return this.model.create(record);
+      return this.model.create(record, options);
     };
 
     Collection.prototype.associated = function(record) {

--- a/src/relation.coffee
+++ b/src/relation.coffee
@@ -47,9 +47,9 @@ class Collection extends Spine.Module
 
     @model.trigger('refresh', @model.cloneArray(records))
 
-  create: (record) ->
+  create: (record, options) ->
     record[@fkey] = @record.id
-    @model.create(record)
+    @model.create(record, options)
 
   # Private
 


### PR DESCRIPTION
This makes `Collection.create()` act the same as `Model.create()`, allowing for stuff like this:

``` coffee
record.relatedRecords().create { attribute: 'value' }, { validate: false }
```
