### PR TITLE
Added "elements" and "events" attributes inheritance

### DIFF
--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -417,7 +417,7 @@ class Controller extends Module
     @events = @constructor.events unless @events
     @elements = @constructor.elements unless @elements
 
-    if parent_prototype = @constructor.prototype.__proto__
+    if parent_prototype = @constructor.__super__
       @events = $.extend({}, parent_prototype.events, @events) if parent_prototype.events
       @elements = $.extend({}, parent_prototype.elements, @elements) if parent_prototype.elements
 

--- a/test/specs/controller.js
+++ b/test/specs/controller.js
@@ -90,4 +90,39 @@ describe("Controller", function(){
     var users = new Users();
     expect(users.el.attr("style")).toEqual("width: 100%");
   });
+
+  describe("inheritance", function() {
+    beforeEach(function() {
+      element = $('<div/>').html('<div class="parent"></div><div class="child"></div>');
+      Users.include({
+        events: {"click .parent": "parentEventHandler"},
+        elements: {".parent": "el1"},
+        parentEventHandler: function() {}
+      });
+
+      ChildUser = Users.sub({
+        el: element,
+        events: {"click .child": "childEventHandler"},
+        elements: {".child": "el2"},
+        childEventHandler: function() {}
+      });
+
+      childUser = new ChildUser();
+    });
+
+    it("should inherit elements from parent controller", function(){
+      expect(childUser.el1).toBeDefined();
+      expect(childUser.el2).toBeDefined();
+    });
+
+    it("should inherit events from parent controller", function(){
+      spyOn(childUser, 'parentEventHandler');
+      spyOn(childUser, 'childEventHandler');
+      childUser.el.find('.parent').click();
+      childUser.el.find('.child').click();
+
+      expect(childUser.parentEventHandler).toHaveBeenCalled();
+      expect(childUser.childEventHandler).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
I suggest merging parent events and elements with the child ones in Spine controller.
Let me show you how it will work:

``` coffeescript
class ParentContoller extends Spine.Controller
  elements:
    '.parent-1': 'el_1'
    '.parent-2': 'el_2'

class ChildController extends ParentContoller
  elements:
    '.child-2': 'el_2'
    '.child-3': 'el_3'

child = new ChildController()

child.el_1 # => $('.parent-1') element
child.el_2 # => $('.child-2')  element
child.el_3 # => $('.child-3')  element
```

The same thing with the events.
Any suggestions?
