### PR TITLE
Fixed multilevel inheritance for controller elements and events

### DIFF
--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -456,9 +456,11 @@ class Controller extends Module
     @events = @constructor.events unless @events
     @elements = @constructor.elements unless @elements
 
-    if parent_prototype = @constructor.__super__
+    context = @
+    while parent_prototype = context.constructor.__super__
       @events = $.extend({}, parent_prototype.events, @events) if parent_prototype.events
       @elements = $.extend({}, parent_prototype.elements, @elements) if parent_prototype.elements
+      context = parent_prototype
 
     @delegateEvents(@events) if @events
     @refreshElements() if @elements

--- a/test/specs/controller.js
+++ b/test/specs/controller.js
@@ -194,36 +194,47 @@ describe("Controller", function(){
 
   describe("inheritance", function() {
     beforeEach(function() {
-      element = $('<div/>').html('<div class="parent"></div><div class="child"></div>');
-      Users.include({
-        events: {"click .parent": "parentEventHandler"},
-        elements: {".parent": "el1"},
-        parentEventHandler: function() {}
+      element = $('<div/>').html('<div class="a-el"></div><div class="b-el"></div><div class="c-el"></div>');
+      A = Spine.Controller.sub({
+        events: {"click .a-el": "aEventHandler"},
+        elements: {".a-el": "elA"},
+        aEventHandler: function() {}
       });
 
-      ChildUser = Users.sub({
+      B = A.sub({
         el: element,
-        events: {"click .child": "childEventHandler"},
-        elements: {".child": "el2"},
-        childEventHandler: function() {}
+        events: {"click .b-el": "bEventHandler"},
+        elements: {".b-el": "elB"},
+        bEventHandler: function() {}
       });
 
-      childUser = new ChildUser();
+      C = B.sub({
+        el: element,
+        events: {"click .c-el": "cEventHandler"},
+        elements: {".c-el": "elC"},
+        cEventHandler: function() {}
+      });
+
+      c = new C();
     });
 
-    it("should inherit elements from parent controller", function(){
-      expect(childUser.el1).toBeDefined();
-      expect(childUser.el2).toBeDefined();
+    it("should inherit elements from parent controllers", function(){
+      expect(c.elA).toBeDefined();
+      expect(c.elB).toBeDefined();
+      expect(c.elC).toBeDefined();
     });
 
-    it("should inherit events from parent controller", function(){
-      spyOn(childUser, 'parentEventHandler');
-      spyOn(childUser, 'childEventHandler');
-      childUser.el.find('.parent').click();
-      childUser.el.find('.child').click();
+    it("should inherit events from parent controllers", function(){
+      spyOn(c, 'aEventHandler');
+      spyOn(c, 'bEventHandler');
+      spyOn(c, 'cEventHandler');
+      c.el.find('.a-el').click();
+      c.el.find('.b-el').click();
+      c.el.find('.c-el').click();
 
-      expect(childUser.parentEventHandler).toHaveBeenCalled();
-      expect(childUser.childEventHandler).toHaveBeenCalled();
+      expect(c.aEventHandler).toHaveBeenCalled();
+      expect(c.bEventHandler).toHaveBeenCalled();
+      expect(c.cEventHandler).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
There is an issue with the controller elements and events inheritance that was suggested by  #430 improvement.
It's occurs then you have more that 2 classes in your inheritance tree. E.g.:

``` coffeescript
class A extends Spine.Controller
  elements:
    ...

class B extends A
  elements:
    ...

class C extends B
  elements:
    ...

c = new C()
```

In this case "c" will only contain elements and events declared in C and B classes, not A, unfortunately.

Current pull request fixes this issue by collecting the elements and events recursively.
All this stuff is also covered with updated specs.

@cengebretson I suggest merging it as soon as possible cause the merged before feature is not working properly and may be confusing.
