### PR TITLE
to underscore ClassName that include dot

### DIFF
--- a/src/relation.coffee
+++ b/src/relation.coffee
@@ -98,7 +98,7 @@ underscore = (str) ->
   str.replace(/::/g, '/')
      .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
      .replace(/([a-z\d])([A-Z])/g, '$1_$2')
-     .replace(/-/g, '_')
+     .replace(/(-|\.)/g, '_')
      .toLowerCase()
 
 Spine.Model.extend


### PR DESCRIPTION
Hi

It would be good if 'fkey' of App.MyClass looks like 'app_my_class' instead of 'app.my_class'

