### PR TITLE
resolved #461. The collection url should compute from the model instance first

### DIFF
--- a/lib/ajax.js
+++ b/lib/ajax.js
@@ -18,6 +18,15 @@
     getURL: function(object) {
       return object && (typeof object.url === "function" ? object.url() : void 0) || object.url;
     },
+    getCollectionURL: function(object) {
+      if (object) {
+        if (typeof object.url === "function") {
+          return this.generateURL(object);
+        } else {
+          return object.url;
+        }
+      }
+    },
     getScope: function(object) {
       var scope;
 
@@ -221,7 +230,7 @@
         type: 'POST',
         contentType: 'application/json',
         data: JSON.stringify(this.record),
-        url: Ajax.getURL(this.model)
+        url: Ajax.getCollectionURL(this.record)
       }).done(this.recordResponse(options)).fail(this.failResponse(options));
     };
 

--- a/src/ajax.coffee
+++ b/src/ajax.coffee
@@ -7,6 +7,13 @@ Ajax =
   getURL: (object) ->
     object and object.url?() or object.url
 
+  getCollectionURL: (object) ->
+    if object
+      if typeof object.url is "function"
+        @generateURL(object)
+      else
+        object.url
+
   getScope: (object) ->
     scope = object and object.scope?() or object.scope
     if scope? and scope.charAt(0) is '/'
@@ -145,7 +152,7 @@ class Singleton extends Base
       type: 'POST'
       contentType: 'application/json'
       data: JSON.stringify(@record)
-      url:  Ajax.getURL(@model)
+      url:  Ajax.getCollectionURL(@record)
     ).done(@recordResponse(options))
      .fail(@failResponse(options))
 

--- a/test/specs/ajax.js
+++ b/test/specs/ajax.js
@@ -132,7 +132,7 @@ describe("Ajax", function(){
     spyOn(jQuery, "ajax").andReturn(jqXHR);
 
     User.first().destroy();
-    
+
     expect(User.count()).toEqual(0);
     jqXHR.resolve({id: "MYID", name: "Phillip", last: "Fry"});
     expect(User.count()).toEqual(0);
@@ -310,5 +310,18 @@ describe("Ajax", function(){
     Spine.Model.host = 'http://example.com';
     expect(User.url()).toBe('http://example.com/admin/users');
     expect(user.url()).toBe('http://example.com/roots/1/users/1');
+  });
+
+  it("should get the collection url from the model instance", function(){
+    Spine.Model.host = '';
+    User.scope = "admin";
+    var user = new User({id: 1});
+    expect(Spine.Ajax.getCollectionURL(user)).toBe('/admin/users');
+
+    user.scope = "/root";
+    expect(Spine.Ajax.getCollectionURL(user)).toBe('/root/users');
+
+    user.scope = function() { return "/roots/" + this.id; };
+    expect(Spine.Ajax.getCollectionURL(user)).toBe('/roots/1/users');
   });
 });


### PR DESCRIPTION
When you try to create multiple models at the same time, the scope maybe change
depending on the particular record being created, so the URLs should reflect
the scope of the model instance, instead of the global class scope.
