### PR TITLE
Swap out Cake for Grunt

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -3,8 +3,8 @@ module.exports = ->
   @initConfig
     # Lint
     coffeelint:
-        source: 'src/**/*.coffee'
-        grunt: 'Gruntfile.coffee'
+      source: 'src/**/*.coffee'
+      grunt: 'Gruntfile.coffee'
 
     # Coffee Compiler
     coffee:
@@ -28,7 +28,7 @@ module.exports = ->
   @loadNpmTasks 'grunt-contrib-watch'
   @loadNpmTasks 'grunt-contrib-coffee'
 
-  # task
+  # tasks
   @registerTask 'lint', ['coffeelint']
   @registerTask 'build', ['coffee']
   @registerTask 'default', ['lint:source', 'build']

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -28,7 +28,7 @@ module.exports = ->
   @loadNpmTasks 'grunt-contrib-watch'
   @loadNpmTasks 'grunt-contrib-coffee'
 
-  # Default task
+  # task
   @registerTask 'lint', ['coffeelint']
   @registerTask 'build', ['coffee']
   @registerTask 'default', ['lint:source', 'build']

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -1,0 +1,34 @@
+module.exports = ->
+  # Configuration
+  @initConfig
+    # Lint
+    coffeelint:
+        source: 'src/**/*.coffee'
+        grunt: 'Gruntfile.coffee'
+
+    # Coffee Compiler
+    coffee:
+      compile:
+        files: [
+          expand: true
+          cwd: 'src'
+          src: '**/*.coffee'
+          dest: 'lib'
+          ext: '.js'
+        ]
+
+    # Watch
+    watch:
+      coffee:
+        files: ['src/**/*.coffee']
+        tasks: ['coffee:compile']
+
+  # Load grunt task plugins
+  @loadNpmTasks 'grunt-coffeelint'
+  @loadNpmTasks 'grunt-contrib-watch'
+  @loadNpmTasks 'grunt-contrib-coffee'
+
+  # Default task
+  @registerTask 'lint', ['coffeelint']
+  @registerTask 'build', ['coffee']
+  @registerTask 'default', ['lint:source', 'build']

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "coffee-script": ">=1.6.2",
     "grunt": "~0.4.1",
     "grunt-contrib-coffee": "~0.7.0",
-    "grunt-contrib-watch": "~0.3.1"
+    "grunt-contrib-watch": "~0.3.1",
+    "grunt-coffeelint": "0.0.6"
   },
   "licenses": [
     {

--- a/package.json
+++ b/package.json
@@ -3,21 +3,34 @@
   "description": "MVC Framework.",
   "version": "1.1.0",
   "author": "maccman",
-  "keywords": ["spine", "coffeescript", "MVC"],
-  "contributors": ["maccman", "aeischeid", "cengebretson", "adambiggs"],
+  "keywords": [
+    "spine",
+    "coffeescript",
+    "MVC"
+  ],
+  "contributors": [
+    "maccman",
+    "aeischeid",
+    "cengebretson",
+    "adambiggs"
+  ],
   "devDependencies": {
-  	"coffee-script": ">=1.6.2"
+    "coffee-script": ">=1.6.2",
+    "grunt": "~0.4.1",
+    "grunt-contrib-coffee": "~0.7.0",
+    "grunt-contrib-watch": "~0.3.1"
   },
-  "licenses":
-    [{
+  "licenses": [
+    {
       "type": "MIT",
       "url": "https://github.com/spine/spine/blob/master/LICENSE"
-    }],
+    }
+  ],
   "repository": {
-    "type" : "git",
+    "type": "git",
     "url": "http://github.com/spine/spine.git"
   },
-  "main" : "./index.js",
+  "main": "./index.js",
   "scripts": {
     "test": "for i in test/*.html; do phantomjs test/lib/run-jasmine.phantom.js file://`pwd`/$i; done"
   }


### PR DESCRIPTION
Hi, I just try to swap out cake for grunt

Cake build   -> grunt build
Cake watch -> grunt watch

Additionally, I add a lint task(coffeelint) for coffeescript, I do find some lint errors in the source, like mix tab indentation and spaces, maybe we can add some configurations for our code style later, I'm not sure yet.
