### PR TITLE
Could Spine Manager deactivate non current controllers prior to activating current one?

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -52,20 +52,19 @@
     };
 
     Manager.prototype.change = function() {
-      var args, cont, current, _i, _len, _ref, _results;
+      var args, cont, current, _i, _len, _ref;
 
       current = arguments[0], args = 2 <= arguments.length ? __slice.call(arguments, 1) : [];
       _ref = this.controllers;
-      _results = [];
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
         cont = _ref[_i];
-        if (cont === current) {
-          _results.push(cont.activate.apply(cont, args));
-        } else {
-          _results.push(cont.deactivate.apply(cont, args));
+        if (cont !== current) {
+          cont.deactivate.apply(cont, args);
         }
       }
-      return _results;
+      if (current) {
+        return current.activate.apply(current, args);
+      }
     };
 
     return Manager;

--- a/src/manager.coffee
+++ b/src/manager.coffee
@@ -26,11 +26,10 @@ class Spine.Manager extends Spine.Module
   # Private
 
   change: (current, args...) ->
-    for cont in @controllers
-      if cont is current
-        cont.activate(args...)
-      else
-        cont.deactivate(args...)
+    for cont in @controllers when cont isnt current
+      cont.deactivate(args...)
+
+    current.activate(args...) if current
 
 Spine.Controller.include
   active: (args...) ->


### PR DESCRIPTION
What I would propose would be deactivating all non current controllers from the controller array and then activating the current one.

https://github.com/maca/spine/blob/dev/src/manager.coffee#L28-33

I want a controller activation to change a global state, but I am finding race conditions (so to speak):

Basically I have some controllers that inherit from Pane, that have a static position on top of the main section, so whenever a Pane is visible I don't want the main page to be scrollable.

```
class Spine.Pane extends Spine.Controller
  activate: ->
    $('body').addClass 'noscroll'
    super

  deactivate: ->
    $('body').removeClass 'noscroll'
    super
```
