### PR TITLE
expose ajax classes as globals for patching

### DIFF
--- a/lib/ajax.js
+++ b/lib/ajax.js
@@ -83,9 +83,6 @@
     },
     clearQueue: function() {
       return this.queue([]);
-    },
-    stringify: function(record) {
-      return JSON.stringify(record);
     }
   };
 
@@ -227,7 +224,7 @@
       return this.ajaxQueue(params, {
         type: 'POST',
         contentType: 'application/json',
-        data: Ajax.stringify(this.record),
+        data: JSON.stringify(this.record),
         url: Ajax.getCollectionURL(this.record)
       }).done(this.recordResponse(options)).fail(this.failResponse(options));
     };
@@ -236,7 +233,7 @@
       return this.ajaxQueue(params, {
         type: 'PUT',
         contentType: 'application/json',
-        data: Ajax.stringify(this.record),
+        data: JSON.stringify(this.record),
         url: Ajax.getURL(this.record)
       }).done(this.recordResponse(options)).fail(this.failResponse(options));
     };

--- a/src/ajax.coffee
+++ b/src/ajax.coffee
@@ -58,9 +58,6 @@ Ajax =
 
   clearQueue: ->
     @queue []
-    
-  stringify: (record) ->
-    JSON.stringify(record)
 
 class Base
   defaults:
@@ -156,7 +153,7 @@ class Singleton extends Base
       params,
       type: 'POST'
       contentType: 'application/json'
-      data: Ajax.stringify(@record)
+      data: JSON.stringify(@record)
       url:  Ajax.getCollectionURL(@record)
     ).done(@recordResponse(options))
      .fail(@failResponse(options))
@@ -166,7 +163,7 @@ class Singleton extends Base
       params,
       type: 'PUT'
       contentType: 'application/json'
-      data: Ajax.stringify(@record)
+      data: JSON.stringify(@record)
       url:  Ajax.getURL(@record)
     ).done(@recordResponse(options))
      .fail(@failResponse(options))


### PR DESCRIPTION
Currently the Ajax module is pretty difficult to patch since most of the classes that it uses internally aren't exposed as global variables.

This patch does two things:
1) Exposes `Base`, `Singleton`, and `Collection` as globals under the Ajax namespace.
2) Creates a `stringify` method on the Ajax object that delegates to `JSON.stringify` to easily overwrite the logic buried in the `Singleton` ajax methods.

The later might not be necessary, as defining `toJSON` on a Spine model kind of does the same thing… however, this seems like a logical place to override if a global serializing behavior is desirable.
