### PR TITLE
Controller::replace should accept jQuery object or DOM Element

### DIFF
--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -586,7 +586,8 @@ class Controller extends Module
     @el
 
   replace: (element) ->
-    element = $.trim(element.el or element)
+    element = element.el or element
+    element = $.trim(element) if typeof element is "string"
     [previous, @el] = [@el, $($.parseHTML(element)?[0] or element)]
     previous.replaceWith(@el)
     @delegateEvents(@events)


### PR DESCRIPTION
I've found, that after latest changes Controller::replace can accept only strings:

``` coffee
element = $ ".dom-element"
console.log $.trim element  # will return "[Object]" instead of original element
```
