### PR TITLE
Add support for redirecting unmatched routes

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -32,7 +32,8 @@
       trigger: true,
       history: false,
       shim: false,
-      replace: false
+      replace: false,
+      redirect: false
     };
 
     Route.add = function(path, callback) {
@@ -81,7 +82,7 @@
     };
 
     Route.navigate = function() {
-      var args, lastArg, options, path;
+      var args, lastArg, options, path, route;
 
       args = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
       options = {};
@@ -99,18 +100,21 @@
       this.path = path;
       this.trigger('navigate', this.path);
       if (options.trigger) {
-        this.matchRoute(this.path, options);
+        route = this.matchRoute(this.path, options);
       }
       if (options.shim) {
         return;
       }
-      if (this.history && options.replace) {
-        return history.replaceState({}, document.title, this.path);
-      } else if (this.history) {
-        return history.pushState({}, document.title, this.path);
-      } else {
-        return window.location.hash = this.path;
+      if (!route && options.redirect) {
+        this.redirect(this.path);
       }
+        if (this.history && options.replace) {
+          return history.replaceState({}, document.title, this.path);
+        } else if (this.history) {
+          return history.pushState({}, document.title, this.path);
+        } else {
+          return window.location.hash = this.path;
+        }
     };
 
     Route.getPath = function() {
@@ -155,6 +159,10 @@
         this.trigger('change', route, path);
         return route;
       }
+    };
+
+    Route.redirect = function(path) {
+      return window.location = path;
     };
 
     function Route(path, callback) {

--- a/src/route.coffee
+++ b/src/route.coffee
@@ -18,6 +18,7 @@ class Spine.Route extends Spine.Module
     history: false
     shim: false
     replace: false
+    redirect: false
 
   @add: (path, callback) ->
     if (typeof path is 'object' and path not instanceof RegExp)
@@ -64,9 +65,12 @@ class Spine.Route extends Spine.Module
 
     @trigger('navigate', @path)
 
-    @matchRoute(@path, options) if options.trigger
+    route = @matchRoute(@path, options) if options.trigger
 
     return if options.shim
+
+    if !route and options.redirect
+      @redirect(@path)
 
     if @history and options.replace
       history.replaceState({}, document.title, @path)
@@ -99,6 +103,9 @@ class Spine.Route extends Spine.Module
     for route in @routes when route.match(path, options)
       @trigger('change', route, path)
       return route
+
+  @redirect: (path) ->
+    window.location = path
 
   constructor: (@path, @callback) ->
     @names = []

--- a/test/specs/route.js
+++ b/test/specs/route.js
@@ -44,10 +44,11 @@ describe("Routing", function () {
       trigger: true,
       history: false,
       shim: false,
-      replace: false
+      replace: false,
+      redirect: false
     });
   });
-  
+
   it("can get the host", function() {
     host = Route.getHost();
     expect(host).not.toBeNull();
@@ -166,6 +167,7 @@ describe("Routing", function () {
             history: false,
             shim: true,
             replace: false,
+            redirect: false,
             match: ["/users/1/2", "1", "2"], id: "1", id2: "2"
           }]));
         });
@@ -180,6 +182,7 @@ describe("Routing", function () {
             history: false,
             shim: true,
             replace: false,
+            redirect: false,
             match: ["/page/gah", "gah"], stuff: "gah"
           }]));
         });
@@ -240,7 +243,7 @@ describe("Routing", function () {
 
       expect(Route.path).toBe('/foo');
     });
-    
+
     it("can navigate", function () {
       Route.add("/users/1", function () {});
 
@@ -295,5 +298,25 @@ describe("Routing", function () {
         expect(window.location.pathname).toBe("/users/1");
       });
     });
+
   });
+
+  describe('With Redirect', function() {
+
+    beforeEach(function () {
+      Route.setup({redirect: true});
+    });
+
+    afterEach(function () {
+      setUrl();
+    });
+
+    it("bubbles unmatched routes to the browser", function() {
+      spyOn(Route, 'redirect');
+      Route.navigate('/unmatched')
+      expect(Route.redirect).toHaveBeenCalledWith('/unmatched');
+    });
+
+  });
+
 });


### PR DESCRIPTION
For applications transitioning to an all-client Spine implementation,
enabling `redirect` in the Spine router will allow unmatched routes to
escape to the browser and are handled by a simple `window.location=`.

For example, suppose I have finished implementing the new List Projects
screen in Spine, but I have not yet implemented the New Project screen
(it is still plain-old HTML/HTTP request/response).

The List Projects controller shouldn't care whether a New Project
controller has been implemented in Spine or if that navigation needs to
be a hard page refresh. By enabling redirects, the List Projects
controller can handle navigational duties using a consistent API.

This is a much bigger issue when HTML5 history support is enabled, as
you can't `pushState` with a plain-old <a> tag the same way you can
change the current hash.

To enable this feature, pass `redirect: true` as an option to the Spine
router during setup, such as:

`Spine.Route.setup(history: true, redirect: true)`

Also see: https://groups.google.com/forum/#!topic/spinejs/bAY1NC6jKoc
