### PR TITLE
typo: remove accidental space in `or=` in spine.coffee

### DIFF
--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -33,7 +33,7 @@ Events =
     this
 
   listenToOnce: (obj, ev, callback) ->
-    listeningToOnce = @listeningToOnce or = []
+    listeningToOnce = @listeningToOnce or= []
     obj.bind ev, handler = ->
       idx = -1
       for lt, i in listeningToOnce when lt.obj is obj


### PR DESCRIPTION
`or =` should be `or=`.
