### PR TITLE
Add support for ajax functions on a has-many relationship

### DIFF
--- a/src/hasManyAjaxCollection.coffee
+++ b/src/hasManyAjaxCollection.coffee
@@ -1,0 +1,56 @@
+# Mimics Spine.Ajax.Collection and provides ajax functions on has_many relations
+class HasManyAjaxCollection extends Spine.Ajax.Base
+
+  # sets the instance vars
+  constructor: (@relation) ->
+
+  # straight copy from Spine.Ajax.Collection
+  find: (id, params, options = {}) ->
+    record = new @relation.model(id: id)
+    @ajaxQueue(
+      params,
+      type: 'GET',
+      url: options.url or Spine.Ajax.getURL(record)
+    ).done(@_recordsResponse)
+     .fail(@_failResponse)
+
+  # straight copy from Spine.Ajax.Collection
+  all: (params, options = {}) ->
+    @ajaxQueue(
+      params,
+      type: 'GET',
+      url: options.url or Spine.Ajax.getURL(@relation)
+    ).done(@_recordsResponse)
+     .fail(@_failResponse)
+
+  # straight copy from Spine.Ajax.Collection
+  fetch: (params = {}, options = {}) ->
+    if id = params.id
+      delete params.id
+      @find(id, params, options).done (record) =>
+        @relation.refresh(record, options)
+    else
+      @all(params, options).done (records) =>
+        @relation.refresh(records, options)
+
+  # Private
+
+  # straight copy from Spine.Ajax.Collection
+  _recordsResponse: (data, status, xhr) =>
+    @relation.model.trigger('ajaxSuccess', null, status, xhr)
+
+  # straight copy from Spine.Ajax.Collection
+  _failResponse: (xhr, statusText, error) =>
+    @relation.model.trigger('ajaxError', null, xhr, statusText, error)
+
+# Patch Spine.Collection (relation) to include Ajax support
+Spine.Collection.include
+
+  # give has_many collections an #ajax method for accessing remote resources
+  ajax: -> new HasManyAjaxCollection(this)
+
+  # add #fetch method to instances
+  fetch: (params) -> @ajax().fetch(arguments...)
+
+  # generate the nested resource url
+  url: (args...) -> @record.url(@name, args...)


### PR DESCRIPTION
Now you can setup relationships between models in Spine and fetch the related data lazily and asynchronously!

Part of a series of ideas I have for Spine, based on ~~monkey-patches~~ freedom-patches I've been amassing in my own projects.

The idea here was that if, say, an `Author` has many `Books`, you can setup the relationship on the models and then call `author.books().fetch()` to trigger an ajax request to `/author/123/books`. 

I'm basically looking for love-it/hate-it feedback. If there's some desire to see this functionality in Spine, I'll follow up with unit tests and so forth to make this a better PR.
