### PR TITLE
Code cleanup

### DIFF
--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -153,7 +153,7 @@ class Model extends Module
 
   @notFound: (id) -> null
 
-  @exists: (id) -> !!@irecords[id]
+  @exists: (id) -> Boolean @irecords[id]
 
   @addRecord: (record, options = {}) ->
     if record.id and @irecords[record.id]


### PR DESCRIPTION
Return statements like these are not required in CoffeeScript.

And `!!statement` is a short version of `if statement then true else false` (both are casting a statement to a boolean).

It feels a bit like this to me:
http://programmers.stackexchange.com/questions/12807/make-a-big-deal-out-of-true

Maybe this was deliberately done for readability but it seemed redundant to me.
