### PR TITLE
Clean up: Removed an unnecessary use of !!

### DIFF
--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -319,8 +319,8 @@ class Model extends Module
     result
 
   eql: (rec) ->
-    !!(rec and rec.constructor is @constructor and
-        ((rec.cid is @cid) or (rec.id and rec.id is @id)))
+    rec and rec.constructor is @constructor and
+      ((rec.cid is @cid) or (rec.id and rec.id is @id))
 
   save: (options = {}) ->
     unless options.validate is false


### PR DESCRIPTION
The statement will be cast to a boolean by using `and` or `or`, so no extra casting (`!!`) is required.
