### PR TITLE
HATEOAS Integration: Adding Model.root & Model.getObjects() hook.

### DIFF
--- a/lib/spine.js
+++ b/lib/spine.js
@@ -293,6 +293,8 @@ Released under the MIT License
 
     Model.extend(Events);
 
+    Model.root = null;
+
     Model.records = [];
 
     Model.irecords = {};
@@ -315,6 +317,14 @@ Released under the MIT License
 
     Model.toString = function() {
       return "" + this.className + "(" + (this.attributes.join(", ")) + ")";
+    };
+
+    Model.getObjects = function(objects) {
+      if (typeof objects === 'object' && this.root && objects.hasOwnProperty(this.root)) {
+        return objects[this.root];
+      } else {
+        return objects;
+      }
     };
 
     Model.find = function(id, notFound) {
@@ -511,6 +521,7 @@ Released under the MIT License
 
     Model.fromJSON = function(objects) {
       var value, _i, _len, _results;
+      objects = this.getObjects(objects);
       if (!objects) {
         return;
       }
@@ -771,6 +782,7 @@ Released under the MIT License
     Model.prototype.refresh = function(data) {
       var root;
       root = this.constructor.irecords[this.id];
+      data = this.constructor.getObjects(data);
       root.load(data);
       this.trigger('refresh');
       return this;

--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -133,6 +133,7 @@ class Module
 class Model extends Module
   @extend Events
 
+  @root       : null
   @records    : []
   @irecords   : {}
   @attributes : []
@@ -147,6 +148,12 @@ class Model extends Module
     this
 
   @toString: -> "#{@className}(#{@attributes.join(", ")})"
+
+  @getObjects: (objects) ->
+    if typeof objects is 'object' and @root and objects.hasOwnProperty(@root)
+      objects[@root]
+    else
+      objects
 
   @find: (id, notFound = @notFound) ->
     @irecords[id]?.clone() or notFound?(id)
@@ -246,6 +253,7 @@ class Model extends Module
     @records
 
   @fromJSON: (objects) ->
+    objects = @getObjects(objects)
     return unless objects
     if typeof objects is 'string'
       objects = JSON.parse(objects)
@@ -403,6 +411,7 @@ class Model extends Module
   refresh: (data) ->
     # go to the source and load attributes
     root = @constructor.irecords[@id]
+    data = @constructor.getObjects(data)
     root.load(data)
     @trigger('refresh')
     @


### PR DESCRIPTION
Used in `Model.fromJSON()` and `Model.prototype.refresh()` to pick off a root data attribute from the server response.

In order to more easily accommodate HATEOAS APIs like [Tastypie](https://django-tastypie.readthedocs.org/en/latest/interacting.html#getting-a-collection-of-resources) which returns an object for collection requests (instead of an array) with a known root data attribute which contains the array, this pull request checks if `Model.root` was set and if so uses the value in `Model.root` to extract the desired data point from the server response.

In my case we have an API that always returns a response like: `{meta: {}, data: [], errors: []}` or `{meta: {}, data: {}, errors: []}` and I set `Model.root = 'data'` with this hook and can now use the default `fromJSON()` method with my API.

Likewise our API returns the `data` root attribute for detail responses and responses for `GET`, `POST`, and `PUT` requests. I was surprised to find that the responses for `PUT` were not run through `fromJSON` which is why I had to add the call to `getObjects` in `refresh`.

UPDATE:
Looks like when `Model.prototype.refresh` was added it removed the call to `fromJSON` which is why I needed to update `refresh` as well. See [Model.save() misbehaving when the server returns non-standard JSON](https://github.com/spine/spine/issues/504) and [1cdef791](https://github.com/spine/spine/commit/1cdef791)

Related but only an issue with older browsers is the [JSON Array Information Disclosure Vulnerability](http://stackoverflow.com/questions/16289894/is-json-hijacking-still-an-issue-in-modern-browsers) with returning an array that is not wrapped in an object.

This Pull Request does not change any existing functionality and is an _opt-in_ feature by setting `Model.root`.

---

The general problem I'm trying to address here is having an easy way to override the default `Model.fromJSON` method while still being able to leverage the existing `Model.fromJSON` method. Alternatively, if `Model.fromJSON` just called `Model._fromJSON` then I could implement my own `Model.fromJSON` and still call `Model._fromJSON` at the appropriate time. Likewise, in my case, I also need the hook on `Model.prototype.refresh` to alter the data object that is coming back to match my model. I feel like there is a hook that is missing that would simplify things.

Thoughts? Questions? Feedback? Concerns?
