### PR TITLE
Readding fromJSON data coercion in recordResponse.

### DIFF
--- a/lib/ajax.js
+++ b/lib/ajax.js
@@ -295,9 +295,9 @@
       return (function(_this) {
         return function(data, status, xhr) {
           var _ref;
-          data = _this.model.fromJSON(data);
           Ajax.disable(function() {
             if (!(Spine.isBlank(data) || _this.record.destroyed)) {
+              data = _this.model.fromJSON(data);
               if (data.id && _this.record.id !== data.id) {
                 _this.record.changeID(data.id);
               }

--- a/src/ajax.coffee
+++ b/src/ajax.coffee
@@ -210,10 +210,9 @@ class Singleton extends Base
 
   recordResponse: (options = {}) =>
     (data, status, xhr) =>
-      data = @model.fromJSON(data)
-
       Ajax.disable =>
         unless Spine.isBlank(data) or @record.destroyed
+          data = @model.fromJSON(data)
           # ID change, need to do some shifting
           if data.id and @record.id isnt data.id
             @record.changeID(data.id)


### PR DESCRIPTION
[Pull Request #486](https://github.com/spine/spine/pull/486/files) removed `data = @model.fromJSON(data)` from `recordResponse` which caused [Issue 504](https://github.com/spine/spine/issues/504).

This Pull Request resolves [Issue 504](https://github.com/spine/spine/issues/504) for people with custom APIs that need `fromJSON` to process their models before loading their data.
