### PR TITLE
Adding Model.beforeFromJSON() hook to tap into the json before the default fromJSON() method runs.

### DIFF
--- a/lib/spine.js
+++ b/lib/spine.js
@@ -318,12 +318,11 @@ Released under the MIT License
     };
 
     Model.find = function(id, notFound) {
-      var record, _ref;
+      var _ref;
       if (notFound == null) {
         notFound = this.notFound;
       }
-      record = (_ref = this.irecords[id]) != null ? _ref.clone() : void 0;
-      return record || (typeof notFound === "function" ? notFound(id) : void 0);
+      return ((_ref = this.irecords[id]) != null ? _ref.clone() : void 0) || (typeof notFound === "function" ? notFound(id) : void 0);
     };
 
     Model.notFound = function(id) {
@@ -331,11 +330,7 @@ Released under the MIT License
     };
 
     Model.exists = function(id) {
-      if (this.irecords[id]) {
-        return true;
-      } else {
-        return false;
-      }
+      return Boolean(this.irecords[id]);
     };
 
     Model.addRecord = function(record, options) {
@@ -509,8 +504,13 @@ Released under the MIT License
       return this.records;
     };
 
+    Model.beforeFromJSON = function(objects) {
+      return objects;
+    };
+
     Model.fromJSON = function(objects) {
       var value, _i, _len, _results;
+      objects = this.beforeFromJSON(objects);
       if (!objects) {
         return;
       }
@@ -637,7 +637,7 @@ Released under the MIT License
     };
 
     Model.prototype.eql = function(rec) {
-      return !!(rec && rec.constructor === this.constructor && ((rec.cid === this.cid) || (rec.id && rec.id === this.id)));
+      return rec && rec.constructor === this.constructor && ((rec.cid === this.cid) || (rec.id && rec.id === this.id));
     };
 
     Model.prototype.save = function(options) {

--- a/lib/spine.js
+++ b/lib/spine.js
@@ -510,13 +510,13 @@ Released under the MIT License
 
     Model.fromJSON = function(objects) {
       var value, _i, _len, _results;
-      objects = this.beforeFromJSON(objects);
       if (!objects) {
         return;
       }
       if (typeof objects === 'string') {
         objects = JSON.parse(objects);
       }
+      objects = this.beforeFromJSON(objects);
       if (isArray(objects)) {
         _results = [];
         for (_i = 0, _len = objects.length; _i < _len; _i++) {

--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -245,7 +245,11 @@ class Model extends Module
   @toJSON: ->
     @records
 
+  @beforeFromJSON: (objects) ->
+    return objects
+
   @fromJSON: (objects) ->
+    objects = @beforeFromJSON(objects)
     return unless objects
     if typeof objects is 'string'
       objects = JSON.parse(objects)

--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -249,10 +249,10 @@ class Model extends Module
     return objects
 
   @fromJSON: (objects) ->
-    objects = @beforeFromJSON(objects)
     return unless objects
     if typeof objects is 'string'
       objects = JSON.parse(objects)
+    objects = @beforeFromJSON(objects)
     if isArray(objects)
       for value in objects
         if value instanceof this


### PR DESCRIPTION
Adding a light `Model.beforeFromJSON()` hook to allow developers to transform their json before the normal `Model.fromJSON()` method runs. The default implementation simply returns the original `objects` data that was passed to it. i.e. a noop.

In my experience `fromJSON()` pretty much does what you want, but when working with custom APIs or HATEOAS APIs like [Tastypie](https://django-tastypie.readthedocs.org/en/latest/interacting.html#getting-a-collection-of-resources) you often need to pick off some root data attribute from the response in `fromJSON()` which leads to a lot of duplicate code. This Pull Request gives you the opportunity to make that small tweak and then let `fromJSON()` do its work.

For APIs that are designed with older browsers and the [JSON Array Information Disclosure Vulnerability](http://stackoverflow.com/questions/16289894/is-json-hijacking-still-an-issue-in-modern-browsers) in mind this Pull Request also helps address collections that are wrapped in an object in the same way.

For APIs where the root object attribute is always known you could do something like this:

```
Spine.Model.root = 'data';
Spine.Model.beforeFromJSON = function(objects) {
    if (typeof objects === 'object' && this.root && objects.hasOwnProperty(this.root)) {
        return objects[this.root];
    } else {
        return objects;
    }
};
```

The example above checks sets a globally known root object attribute `data` and then checks if `objects` is an `object` with the `data` attribute and if so, returns just the `data` attribute.

In my case we have an API that always returns a response like: `{meta: {}, data: [], errors: []}` or `{meta: {}, data: {}, errors: []}` and I use a setup like the example above so my models can use the default `fromJSON()` method.