### PR TITLE
Use Model.fromJSON in Model.prototype.refresh

### DIFF
--- a/lib/spine.js
+++ b/lib/spine.js
@@ -771,6 +771,7 @@ Released under the MIT License
     Model.prototype.refresh = function(data) {
       var root;
       root = this.constructor.irecords[this.id];
+      data = this.constructor.fromJSON(data);
       root.load(data);
       this.trigger('refresh');
       return this;

--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -403,6 +403,7 @@ class Model extends Module
   refresh: (data) ->
     # go to the source and load attributes
     root = @constructor.irecords[@id]
+    data = @constructor.fromJSON(data)
     root.load(data)
     @trigger('refresh')
     @


### PR DESCRIPTION
This seems like a better solution than https://github.com/spine/spine/pull/541 as fromJSON will be called when `Model.prototype.refresh` is used directly.
