### PR TITLE
ie9-tests-fix > Fix tests on IE9.

### DIFF
--- a/test/specs/controller.js
+++ b/test/specs/controller.js
@@ -59,7 +59,7 @@ describe("Controller", function(){
       attributes: {"style": "width: 100%"}
     });
     var users = new Users();
-    expect(users.el.attr("style")).toEqual("width: 100%");
+    expect(users.el.attr("style")).toMatch("width: 100%");
   });
 
   describe("When binding DOM events", function(){

--- a/test/specs/model.js
+++ b/test/specs/model.js
@@ -36,7 +36,7 @@ describe("Model", function(){
 
   it("can keep record clones in sync after refreshing the record", function(){
     var asset = Asset.create({name: "test.pdf"});
-    expect(asset.__proto__).toEqual(Asset.irecords[asset.id]);
+    expect(Object.getPrototypeOf(asset)).toEqual(Asset.irecords[asset.id]);
 
     var changedAsset = asset.toJSON();
     changedAsset.name = "wem.pdf";
@@ -47,8 +47,8 @@ describe("Model", function(){
 
     expect(asset.name).toEqual("wem.pdf");
     expect(selectedAsset.name).toEqual("wem.pdf");
-    expect(asset.__proto__).toBe(Asset.irecords[asset.id]);
-    expect(selectedAsset.__proto__).toBe(Asset.irecords[asset.id]);
+    expect(Object.getPrototypeOf(asset)).toBe(Asset.irecords[asset.id]);
+    expect(Object.getPrototypeOf(selectedAsset)).toBe(Asset.irecords[asset.id]);
   });
 
   it("can destroy records", function(){
@@ -125,7 +125,7 @@ describe("Model", function(){
     expect(asset.name).toEqual("foo.pdf");
 
     // Reload should return a clone, more useful that way
-    expect(original.__proto__.__proto__).toEqual(Asset.prototype)
+    expect(Object.getPrototypeOf(Object.getPrototypeOf(original))).toEqual(Asset.prototype)
   });
 
   it("can refresh", function(){
@@ -390,7 +390,7 @@ describe("Model", function(){
 
   it("can be duplicated", function(){
     var asset = Asset.create({name: "who's your daddy?"});
-    expect(asset.dup().__proto__).toBe(Asset.prototype);
+    expect(Object.getPrototypeOf(asset.dup())).toBe(Asset.prototype);
 
     expect(asset.name).toEqual("who's your daddy?");
     asset.name = "I am your father";
@@ -401,8 +401,8 @@ describe("Model", function(){
 
   it("can be cloned", function(){
     var asset = Asset.create({name: "what's cooler than cool?"}).dup(false);
-    expect(asset.clone().__proto__).not.toBe(Asset.prototype);
-    expect(asset.clone().__proto__.__proto__).toBe(Asset.prototype);
+    expect(Object.getPrototypeOf(asset.clone())).not.toBe(Asset.prototype);
+    expect(Object.getPrototypeOf(Object.getPrototypeOf(asset.clone()))).toBe(Asset.prototype);
 
     expect(asset.name).toEqual("what's cooler than cool?");
     asset.name = "ice cold";
@@ -423,8 +423,8 @@ describe("Model", function(){
 
   it("create or save should return a clone", function(){
     var asset = Asset.create({name: "what's cooler than cool?"});
-    expect(asset.__proto__).not.toBe(Asset.prototype);
-    expect(asset.__proto__.__proto__).toBe(Asset.prototype);
+    expect(Object.getPrototypeOf(asset)).not.toBe(Asset.prototype);
+    expect(Object.getPrototypeOf(Object.getPrototypeOf(asset))).toBe(Asset.prototype);
   });
 
   it("should be able to be subclassed", function(){
@@ -681,13 +681,13 @@ describe("Model", function(){
 
     it("it should pass clones with events", function(){
       Asset.bind("create", function(asset){
-        expect(asset.__proto__).not.toBe(Asset.prototype);
-        expect(asset.__proto__.__proto__).toBe(Asset.prototype);
+        expect(Object.getPrototypeOf(asset)).not.toBe(Asset.prototype);
+        expect(Object.getPrototypeOf(Object.getPrototypeOf(asset))).toBe(Asset.prototype);
       });
 
       Asset.bind("update", function(asset){
-        expect(asset.__proto__).not.toBe(Asset.prototype);
-        expect(asset.__proto__.__proto__).toBe(Asset.prototype);
+        expect(Object.getPrototypeOf(asset)).not.toBe(Asset.prototype);
+        expect(Object.getPrototypeOf(Object.getPrototypeOf(asset))).toBe(Asset.prototype);
       });
       var asset = Asset.create({name: "cartoon world.png"});
       asset.updateAttributes({name: "lonely heart.png"});


### PR DESCRIPTION
Use Object.getPrototypeOf instead of **proto** to fix breaking tests on IE9 and use toMatch for Controller element attributes test to account for IE appending a semicolon to returned style declarations.
