### PR TITLE
Moved changeID() to Model.prototype.refresh and updated fromJSON(data) usage

### DIFF
--- a/lib/ajax.js
+++ b/lib/ajax.js
@@ -297,13 +297,10 @@
           var _ref;
           Ajax.disable(function() {
             if (!(Spine.isBlank(data) || _this.record.destroyed)) {
-              if (data.id && _this.record.id !== data.id) {
-                _this.record.changeID(data.id);
-              }
               return _this.record.refresh(data);
             }
           });
-          _this.record.trigger('ajaxSuccess', data, status, xhr);
+          _this.record.trigger('ajaxSuccess', _this.model.fromJSON(data), status, xhr);
           return (_ref = options.done) != null ? _ref.apply(_this.record) : void 0;
         };
       })(this);

--- a/lib/spine.js
+++ b/lib/spine.js
@@ -770,6 +770,10 @@ Released under the MIT License
 
     Model.prototype.refresh = function(data) {
       var root;
+      data = this.constructor.fromJSON(data);
+      if (data.id && this.id !== data.id) {
+        this.changeID(data.id);
+      }
       root = this.constructor.irecords[this.id];
       root.load(data);
       this.trigger('refresh');

--- a/src/ajax.coffee
+++ b/src/ajax.coffee
@@ -213,13 +213,10 @@ class Singleton extends Base
 
       Ajax.disable =>
         unless Spine.isBlank(data) or @record.destroyed
-          # ID change, need to do some shifting
-          if data.id and @record.id isnt data.id
-            @record.changeID(data.id)
           # Update with latest data
           @record.refresh(data)
 
-      @record.trigger('ajaxSuccess', data, status, xhr)
+      @record.trigger('ajaxSuccess', @model.fromJSON(data), status, xhr)
       options.done?.apply(@record)
 
   failResponse: (options = {}) =>

--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -401,6 +401,10 @@ class Model extends Module
     original
 
   refresh: (data) ->
+    data = @constructor.fromJSON(data)
+    # ID change, need to do some shifting
+    if data.id and @id isnt data.id
+      @changeID(data.id)
     # go to the source and load attributes
     root = @constructor.irecords[@id]
     root.load(data)


### PR DESCRIPTION
Moved changeID call from recordResponse to Model.prototype.refresh
Added fromJSON(data) to Model.prototype.refresh and ajaxSuccess trigger in recordResponse.

Combines https://github.com/spine/spine/pull/543 and https://github.com/spine/spine/pull/541