### PR TITLE
Ajax module updates - Fixes #388 and #502

### DIFF
--- a/lib/ajax.js
+++ b/lib/ajax.js
@@ -322,10 +322,28 @@
       return (function(_this) {
         return function(xhr, statusText, error, settings) {
           var ref;
+          switch (settings.type) {
+            case 'POST':
+              _this.createFailed();
+              break;
+            case 'DELETE':
+              _this.destroyFailed();
+          }
           _this.record.trigger('ajaxError', _this.record, xhr, statusText, error, settings);
           return (ref = options.fail) != null ? ref.call(_this.record, settings) : void 0;
         };
       })(this);
+    };
+
+    Singleton.prototype.createFailed = function() {
+      return this.record.remove({
+        clear: true
+      });
+    };
+
+    Singleton.prototype.destroyFailed = function() {
+      this.record.destroyed = false;
+      return this.record.constructor.refresh(this.record);
     };
 
     return Singleton;

--- a/lib/ajax.js
+++ b/lib/ajax.js
@@ -118,7 +118,7 @@
       settings = this.ajaxSettings(params, defaults);
       parallel = settings.parallel !== void 0 ? settings.parallel : settings.type === 'GET';
       request = function(next) {
-        var ref;
+        var ref, reject, resolve;
         if ((record != null ? record.id : void 0) != null) {
           if (settings.url == null) {
             settings.url = Ajax.getURL(record);
@@ -130,9 +130,15 @@
         if (typeof settings.data !== 'string' && settings.processData !== true) {
           settings.data = JSON.stringify(settings.data);
         }
+        resolve = function() {
+          return deferred.resolve.apply(this, slice.call(arguments).concat([settings]));
+        };
+        reject = function() {
+          return deferred.reject.apply(this, slice.call(arguments).concat([settings]));
+        };
         jqXHR = $.ajax(settings);
-        jqXHR.done(deferred.resolve);
-        jqXHR.fail(deferred.reject);
+        jqXHR.done(resolve);
+        jqXHR.fail(reject);
         jqXHR.then(next, next);
         if (parallel) {
           return Queue.dequeue();
@@ -221,12 +227,12 @@
       }
     };
 
-    Collection.prototype.recordsResponse = function(data, status, xhr) {
-      return this.model.trigger('ajaxSuccess', null, status, xhr);
+    Collection.prototype.recordsResponse = function(data, status, xhr, settings) {
+      return this.model.trigger('ajaxSuccess', null, status, xhr, settings);
     };
 
-    Collection.prototype.failResponse = function(xhr, statusText, error) {
-      return this.model.trigger('ajaxError', null, xhr, statusText, error);
+    Collection.prototype.failResponse = function(xhr, statusText, error, settings) {
+      return this.model.trigger('ajaxError', null, xhr, statusText, error, settings);
     };
 
     return Collection;
@@ -296,15 +302,15 @@
         options = {};
       }
       return (function(_this) {
-        return function(data, status, xhr) {
+        return function(data, status, xhr, settings) {
           var ref;
-          Ajax.disable(function() {
-            if (!(data === void 0 || Object.getOwnPropertyNames(data).length === 0 || _this.record.destroyed)) {
-              return _this.record.refresh(data);
-            }
-          });
-          _this.record.trigger('ajaxSuccess', _this.record, _this.model.fromJSON(data), status, xhr);
-          return (ref = options.done) != null ? ref.apply(_this.record) : void 0;
+          if ((data != null) && Object.getOwnPropertyNames(data).length && !_this.record.destroyed) {
+            _this.record.refresh(data, {
+              ajax: false
+            });
+          }
+          _this.record.trigger('ajaxSuccess', _this.record, _this.model.fromJSON(data), status, xhr, settings);
+          return (ref = options.done) != null ? ref.call(_this.record, settings) : void 0;
         };
       })(this);
     };
@@ -314,10 +320,10 @@
         options = {};
       }
       return (function(_this) {
-        return function(xhr, statusText, error) {
+        return function(xhr, statusText, error, settings) {
           var ref;
-          _this.record.trigger('ajaxError', _this.record, xhr, statusText, error);
-          return (ref = options.fail) != null ? ref.apply(_this.record) : void 0;
+          _this.record.trigger('ajaxError', _this.record, xhr, statusText, error, settings);
+          return (ref = options.fail) != null ? ref.call(_this.record, settings) : void 0;
         };
       })(this);
     };

--- a/lib/ajax.js
+++ b/lib/ajax.js
@@ -189,7 +189,7 @@
         type: options.method || Ajax.config.loadMethod,
         url: options.url || Ajax.getURL(record),
         parallel: options.parallel
-      }).done(this.recordsResponse).fail(this.failResponse);
+      }).done(this.recordsResponse(options)).fail(this.failResponse(options));
     };
 
     Collection.prototype.all = function(params, options) {
@@ -200,7 +200,7 @@
         type: options.method || Ajax.config.loadMethod,
         url: options.url || Ajax.getURL(this.model),
         parallel: options.parallel
-      }).done(this.recordsResponse).fail(this.failResponse);
+      }).done(this.recordsResponse(options)).fail(this.failResponse(options));
     };
 
     Collection.prototype.fetch = function(params, options) {
@@ -227,12 +227,24 @@
       }
     };
 
-    Collection.prototype.recordsResponse = function(data, status, xhr, settings) {
-      return this.model.trigger('ajaxSuccess', null, status, xhr, settings);
+    Collection.prototype.recordsResponse = function(options) {
+      return (function(_this) {
+        return function(data, status, xhr, settings) {
+          var ref;
+          _this.model.trigger('ajaxSuccess', null, status, xhr, settings);
+          return (ref = options.done) != null ? ref.call(_this.model, settings) : void 0;
+        };
+      })(this);
     };
 
-    Collection.prototype.failResponse = function(xhr, statusText, error, settings) {
-      return this.model.trigger('ajaxError', null, xhr, statusText, error, settings);
+    Collection.prototype.failResponse = function(options) {
+      return (function(_this) {
+        return function(xhr, statusText, error, settings) {
+          var ref;
+          _this.model.trigger('ajaxError', null, xhr, statusText, error, settings);
+          return (ref = options.fail) != null ? ref.call(_this.model, settings) : void 0;
+        };
+      })(this);
     };
 
     return Collection;
@@ -298,9 +310,6 @@
     };
 
     Singleton.prototype.recordResponse = function(options) {
-      if (options == null) {
-        options = {};
-      }
       return (function(_this) {
         return function(data, status, xhr, settings) {
           var ref;
@@ -316,9 +325,6 @@
     };
 
     Singleton.prototype.failResponse = function(options) {
-      if (options == null) {
-        options = {};
-      }
       return (function(_this) {
         return function(xhr, statusText, error, settings) {
           var ref;

--- a/src/ajax.coffee
+++ b/src/ajax.coffee
@@ -129,7 +129,7 @@ class Collection extends Base
         parallel: options.parallel
       }
     ).done(@recordsResponse)
-     .fail(@failResponse)
+      .fail(@failResponse)
 
   all: (params, options = {}) ->
     @ajaxQueue(
@@ -139,7 +139,7 @@ class Collection extends Base
         parallel: options.parallel
       }
     ).done(@recordsResponse)
-     .fail(@failResponse)
+      .fail(@failResponse)
 
   fetch: (params = {}, options = {}) ->
     if id = params.id
@@ -170,7 +170,7 @@ class Singleton extends Base
         parallel: options.parallel
       }, @record
     ).done(@recordResponse(options))
-     .fail(@failResponse(options))
+      .fail(@failResponse(options))
 
   create: (params, options = {}) ->
     @ajaxQueue(
@@ -182,7 +182,7 @@ class Singleton extends Base
         parallel: options.parallel
       }
     ).done(@recordResponse(options))
-     .fail(@failResponse(options))
+      .fail(@failResponse(options))
 
   update: (params, options = {}) ->
     @ajaxQueue(
@@ -194,7 +194,7 @@ class Singleton extends Base
         parallel: options.parallel
       }, @record
     ).done(@recordResponse(options))
-     .fail(@failResponse(options))
+      .fail(@failResponse(options))
 
   destroy: (params, options = {}) ->
     @ajaxQueue(
@@ -204,7 +204,7 @@ class Singleton extends Base
         parallel: options.parallel
       }, @record
     ).done(@recordResponse(options))
-     .fail(@failResponse(options))
+      .fail(@failResponse(options))
 
   # Private
 

--- a/src/ajax.coffee
+++ b/src/ajax.coffee
@@ -222,8 +222,18 @@ class Singleton extends Base
 
   failResponse: (options = {}) =>
     (xhr, statusText, error, settings) =>
+      switch settings.type
+        when 'POST' then @createFailed()
+        when 'DELETE' then @destroyFailed()
       @record.trigger('ajaxError', @record, xhr, statusText, error, settings)
       options.fail?.call(@record, settings)
+
+  createFailed: ->
+    @record.remove(clear: true)
+
+  destroyFailed: ->
+    @record.destroyed = false
+    @record.constructor.refresh(@record)
 
 # Ajax endpoint
 Model.host = ''

--- a/test/specs/ajax.js
+++ b/test/specs/ajax.js
@@ -416,6 +416,22 @@ describe("Ajax", function(){
     expect(spy).toHaveBeenCalled();
   });
 
+  it("removes new records from model storage if creation fails on the server", function(){
+    var user = User.create({first: "Adam"});
+    expect(User.count()).toEqual(1);
+    jasmine.Ajax.requests.mostRecent().respondWith({status: 501});
+    expect(User.count()).toEqual(0);
+    expect(user.destroyed).toBeFalsy();
+  });
+
+  it("restores destroyed records in model storage if deletion fails on the server", function(){
+    var user = User.create({first: "Adam"}, {ajax: false});
+    user.destroy();
+    expect(User.count()).toEqual(0);
+    jasmine.Ajax.requests.mostRecent().respondWith({status: 501});
+    expect(User.count()).toEqual(1);
+    expect(user.destroyed).toBeFalsy();
+  });
 
   it("can be disabled in method options", function() {
     User.create({first: "Second"}, {ajax: false});

--- a/test/specs/ajax.js
+++ b/test/specs/ajax.js
@@ -358,12 +358,61 @@ describe("Ajax", function(){
     expect(spy).toHaveBeenCalled();
   });
 
+  it("should pass request settings into done callbacks", function(){
+    var spy = jasmine.createSpy();
+    User.create({first: "Second"}, {done: spy});
+
+    var serverAttrs = {first: "Second"};
+    jasmine.Ajax.requests.mostRecent().respondWith({
+      status: 200,
+      responseText: JSON.stringify(serverAttrs)
+    });
+
+    var args = spy.calls.mostRecent().args
+    expect(args[0]).toBeDefined();
+  });
+
+  it("should trigger an 'ajaxSuccess' event", function(){
+    var spy = jasmine.createSpy();
+    var user = new User({first: "Adam"});
+    user.on('ajaxSuccess', spy);
+    user.save();
+
+    expect(spy).not.toHaveBeenCalled();
+
+    var serverAttrs = {first: "Adam"};
+    jasmine.Ajax.requests.mostRecent().respondWith({
+      status: 200,
+      responseText: JSON.stringify(serverAttrs)
+    });
+
+    expect(spy).toHaveBeenCalled();
+  });
+
   it("should have fail callbacks", function(){
     var spy = jasmine.createSpy();
     User.create({first: "Second"}, {fail: spy});
 
     jasmine.Ajax.requests.mostRecent().respondWith({ status: 400 });
 
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("should pass request settings into fail callbacks", function(){
+    var spy = jasmine.createSpy();
+    User.create({first: "Second"}, {fail: spy});
+    jasmine.Ajax.requests.mostRecent().respondWith({status: 501});
+    var args = spy.calls.mostRecent().args
+    expect(args[0]).toBeDefined();
+  });
+
+  it("should trigger an 'ajaxError' event", function(){
+    var spy = jasmine.createSpy();
+    var user = new User({first: "Adam"});
+    user.on('ajaxError', spy);
+    user.save();
+    expect(spy).not.toHaveBeenCalled();
+    jasmine.Ajax.requests.mostRecent().respondWith({status: 501});
     expect(spy).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
A few updates to the Ajax module:

- Ajax callbacks  now have access to the request `settings` object, enabling some useful extra logic based on request params (see below)
- If a `POST` request fails, the record is removed from model storage so that the next retry is sent as another `POST` (#388)
- If a `DELETE` request fails, the record is restored in model storage with `@destroyed` set to `false`
- `Collection` requests now have optional `done()`/`fail()` callbacks to match `Singleton` requests (#502)

This doesn't deal with failed `PUT` requests yet (#369), because that's a harder problem to solve...