### PR TITLE
Add Events::stopListening Fix

### DIFF
--- a/lib/spine.js
+++ b/lib/spine.js
@@ -104,13 +104,13 @@ Released under the MIT License
         this.listeningTo = void 0;
         this.listeningToOnce = void 0;
       } else if (obj) {
+        events = events ? events.split(' ') : [void 0];
         ref1 = [this.listeningTo, this.listeningToOnce];
         for (l = 0, len2 = ref1.length; l < len2; l++) {
           listeningTo = ref1[l];
-          if (!listeningTo) {
+          if (!(typeof listeningTo !== "undefined" && listeningTo !== null ? listeningTo.length : void 0)) {
             continue;
           }
-          events = events ? events.split(' ') : [void 0];
           for (m = 0, len3 = events.length; m < len3; m++) {
             ev = events[m];
             for (idx = n = ref2 = listeningTo.length - 1; ref2 <= 0 ? n <= 0 : n >= 0; idx = ref2 <= 0 ? ++n : --n) {

--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -46,16 +46,16 @@ Events =
   stopListening: (obj, events, callback) ->
     if arguments.length is 0
       for listeningTo in [@listeningTo, @listeningToOnce]
-        continue unless listeningTo
+        continue unless listeningTo?.length
         for lt in listeningTo
           lt.obj.unbind(lt.ev, lt.callback)
       @listeningTo = undefined
       @listeningToOnce = undefined
 
     else if obj
+      events = if events then events.split(' ') else [undefined]
       for listeningTo in [@listeningTo, @listeningToOnce]
         continue unless listeningTo
-        events = if events then events.split(' ') else [undefined]
         for ev in events
           for idx in [listeningTo.length-1..0]
             lt = listeningTo[idx]

--- a/test/specs/events.js
+++ b/test/specs/events.js
@@ -12,23 +12,23 @@ describe("Events", function(){
     var spy2 = jasmine.createSpy('globalSpy');
     Spine.bind('notify', spy2);
     EventTest.bind("daddyo", spy);
-    
+
     EventTest.trigger("somethingElse");
     expect(spy).not.toHaveBeenCalled();
-    
+
     EventTest.trigger("daddyo");
     expect(spy).toHaveBeenCalled();
     expect(spy2).not.toHaveBeenCalled();
   });
-  
+
   it("can bind/trigger global events", function(){
     var spy2 = jasmine.createSpy('globalSpy');
     Spine.bind('notify', spy2);
     EventTest.bind("daddyo", spy);
-    
+
     Spine.trigger('somethingElse')
     expect(spy2).not.toHaveBeenCalled();
-    
+
     Spine.trigger("notify");
     expect(spy2).toHaveBeenCalled();
     expect(spy).not.toHaveBeenCalled();
@@ -72,10 +72,10 @@ describe("Events", function(){
     var spy2 = jasmine.createSpy('globalSpy');
     Spine.bind('notify', spy2);
     EventTest.bind("yoyo", spy);
-    
+
     EventTest.trigger("yoyo", 5, 10);
     expect(spy).toHaveBeenCalledWith(5, 10);
-    
+
     Spine.trigger("notify", 'a message');
     expect(spy2).toHaveBeenCalledWith('a message');
   });
@@ -84,7 +84,7 @@ describe("Events", function(){
     EventTest.bind("daddyo", spy);
     var spy2 = jasmine.createSpy('globalSpy');
     Spine.bind('notify', spy2);
-        
+
     EventTest.unbind("daddyo");
     Spine.unbind('notify');
     EventTest.trigger("daddyo");
@@ -175,7 +175,7 @@ describe("Events", function(){
     EventTest.trigger("indahouse");
     expect(spy).not.toHaveBeenCalled();
   });
-  
+
   it("can bind to a global event only once", function(){
     var spy2 = jasmine.createSpy('globalSpy');
     Spine.one('notify', spy2);
@@ -275,5 +275,17 @@ describe("Events", function(){
     EventTest.trigger("house");
     expect(spy).toHaveBeenCalled();
   });
-});
 
+  it("should stop listening only on the specified events", function() {
+    var spy2 = jasmine.createSpy();
+    ListenTest = Spine.Class.create();
+    ListenTest.extend(Spine.Events);
+    ListenTest.listenToOnce(EventTest, "dastardly1", spy);
+    ListenTest.listenTo(EventTest, "dastardly2", spy2);
+    EventTest.trigger("dastardly2");
+    ListenTest.stopListening(EventTest, "dastardly2");
+    EventTest.trigger("dastardly1");
+    expect(spy).toHaveBeenCalled();
+    expect(spy2).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Ran into what appears to be a bug in the `Events::stopListening()`.

___Reproduction:___
- `listenToOnce` to an event on a model
- `listenTo` to a second event on the same model
- `stopListening` to the second event
- the `listenToOnce` function will not be called when its event fires

___Expectation:___
I would expect that the `listenToOnce` would remain, as `stopListening` was given a specific event to stopListening to on that model.