### PR TITLE
Fixes inconsistent behaviour when populating hasOne/belongsTo relationships

### DIFF
--- a/lib/relation.js
+++ b/lib/relation.js
@@ -149,12 +149,7 @@
       if (value == null) {
         return this;
       }
-      if (!(value instanceof this.model)) {
-        value = new this.model(value);
-      }
-      if (value.isNew()) {
-        value.save();
-      }
+      value = this.model.refresh(value)[0];
       this.record[this.fkey] = value && value.id;
       return this;
     };
@@ -185,11 +180,8 @@
       if (value == null) {
         return this;
       }
-      if (!(value instanceof this.model)) {
-        value = this.model.fromJSON(value);
-      }
       value[this.fkey] = this.record.id;
-      value.save();
+      this.model.refresh(value);
       return this;
     };
 

--- a/src/relation.coffee
+++ b/src/relation.coffee
@@ -73,9 +73,7 @@ class Instance extends Spine.Module
 
   update: (value) ->
     return this unless value?
-    unless value instanceof @model
-      value = new @model(value)
-    value.save() if value.isNew()
+    value = @model.refresh(value)[0]
     @record[@fkey] = value and value.id
     this
 
@@ -89,11 +87,8 @@ class Singleton extends Spine.Module
 
   update: (value) ->
     return this unless value?
-    unless value instanceof @model
-      value = @model.fromJSON(value)
-
     value[@fkey] = @record.id
-    value.save()
+    @model.refresh(value)
     this
 
 singularize = (str) ->
@@ -101,10 +96,10 @@ singularize = (str) ->
 
 underscore = (str) ->
   str.replace(/::/g, '/')
-     .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
-     .replace(/([a-z\d])([A-Z])/g, '$1_$2')
-     .replace(/(-|\.)/g, '_')
-     .toLowerCase()
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
+    .replace(/([a-z\d])([A-Z])/g, '$1_$2')
+    .replace(/(-|\.)/g, '_')
+    .toLowerCase()
 
 requireModel = (model) ->
   if typeof model is 'string'

--- a/test/model.relation.js
+++ b/test/model.relation.js
@@ -1,10 +1,10 @@
 describe("Model.Relation", function(){
-  var Album;
-  var Photo;
+  var Album, Photo, spy;
 
   beforeEach(function(){
     Album = Spine.Model.setup("Album", ["name"]);
     Photo = Spine.Model.setup("Photo", ["name"]);
+    spy = jasmine.createSpy();
   });
 
   it("should honour hasMany associations", function(){
@@ -109,6 +109,38 @@ describe("Model.Relation", function(){
     expect( album.photo().name ).toBe("Beautiful photo");
   });
 
+  it("doesn't trigger 'create' events when populating hasOne relationships", function(){
+    Album.hasOne("photo", Photo);
+    Photo.belongsTo("album", Album);
+    Photo.on("create", spy);
+
+    var album = Album.create({
+      name: "Beautiful album",
+      photo: {
+        name: "Beautiful photo"
+      },
+      id: "1"
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("doesn't trigger 'create' events when populating belongsTo relationships", function(){
+    Album.hasOne("photo", Photo);
+    Photo.belongsTo("album", Album);
+    Album.on("create", spy);
+
+    var photo = Photo.create({
+      name: "Beautiful photo",
+      album: {
+        name: "Beautiful album"
+      },
+      id: "1"
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
   it("can create new parent and related Singleton record at once if UUIDs are enabled", function(){
     Album.uuid = function(){ return 'fc0942b0-956f-11e2-9c95-9b0af2c6635d' };
     Photo.uuid = function(){ return '2d08ad90-9572-11e2-9c95-9b0af2c6635d' };
@@ -175,8 +207,8 @@ describe("Model.Relation", function(){
     });
 
     Photo.create({
-	    id: "3",
-	    name: "This record should NOT be removed"
+      id: "3",
+      name: "This record should NOT be removed"
     });
 
     expect( Photo.count() ).toBe(2);

--- a/test/model.relation.js
+++ b/test/model.relation.js
@@ -141,7 +141,7 @@ describe("Model.Relation", function(){
     expect(spy).not.toHaveBeenCalled();
   });
 
-  it("can create new parent and related Singleton record at once if UUIDs are enabled", function(){
+  it("can create nested belongsTo record if UUIDs are enabled", function(){
     Album.uuid = function(){ return 'fc0942b0-956f-11e2-9c95-9b0af2c6635d' };
     Photo.uuid = function(){ return '2d08ad90-9572-11e2-9c95-9b0af2c6635d' };
 
@@ -160,6 +160,29 @@ describe("Model.Relation", function(){
     expect( album.photo() ).toBeTruthy();
     expect( album.photo().album_id ).toEqual(Album.uuid());
     expect( album.photo().name ).toBe("Beautiful photo");
+
+    delete Album.uuid
+    delete Photo.uuid
+  });
+
+  it("can create nested hasOne record if UUIDs are enabled", function(){
+    Album.uuid = function(){ return 'fc0942b0-956f-11e2-9c95-9b0af2c6635d' };
+    Photo.uuid = function(){ return '2d08ad90-9572-11e2-9c95-9b0af2c6635d' };
+
+    Album.hasOne("photo", Photo);
+    Photo.belongsTo("album", Album);
+
+    var photo = new Photo({
+      name: "Beautiful photo",
+      album: {
+        name: "Beautiful album"
+      }
+    });
+
+    expect( photo ).toBeTruthy();
+    expect( photo.id ).toEqual(Photo.uuid());
+    expect( photo.album() ).toBeTruthy();
+    expect( photo.album().name ).toBe("Beautiful album");
 
     delete Album.uuid
     delete Photo.uuid


### PR DESCRIPTION
Fixes #598 & #172.

Use `refresh()` when populating `hasOne`/`belongsTo` relationships to be consistent with how `hasMany` works.

This prevents unexpected ajax calls when the server returns related records nested inside a parent record.
### Breaking Change

``` coffee
Person.hasOne('dog', Dog)
Dog.belongsTo('person', Person)

var person = Person.create({
  name: 'John'
  dog: { name: 'Spot' }
})
```

Previously the above would trigger `'create'` on both the `Person` and `Dog` models. If both models are using ajax, it would send two `POST` requests.

But now `'create'` would only be triggered on the `Person` model, and `'refresh'` would be triggered on the `Dog` model. A `POST` would only be sent for the new `Person` record.
##### Possible Solution

If you include the relation name in the model `attributes`, the related record will be included on it's way back to the server:

``` coffee
Person.attributes.push('dog') # Or just add it when configuring the model.
JSON.stringify(person) # Now includes the nested `Dog` record.
```

But this might require server-side changes, and it doesn't work the same for `hasMany` relationships.

A more ugly workaround that wouldn't require server-side changes:

``` coffee
var person = Person.create({
  name: 'John'
  dog: { name: 'Spot' }
})
person.dog().ajax().create()
```
