### PR TITLE
Don't touch instance `_callbacks` object when loading model attributes

### DIFF
--- a/lib/spine.js
+++ b/lib/spine.js
@@ -599,6 +599,9 @@ Released under the MIT License
       }
       for (key in atts) {
         value = atts[key];
+        if (key === '_callbacks') {
+          continue;
+        }
         if (typeof this[key] === 'function') {
           if (typeof value === 'function') {
             continue;

--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -311,6 +311,7 @@ class Model extends Module
   load: (atts) ->
     if atts.id then @id = atts.id
     for key, value of atts
+      continue if key is '_callbacks'
       if typeof @[key] is 'function'
         continue if typeof value is 'function'
         @[key](value)

--- a/test/specs/model.js
+++ b/test/specs/model.js
@@ -432,6 +432,20 @@ describe("Model", function(){
     expect(spy).toHaveBeenCalledWith("setter value");
   });
 
+  it("respects existing event listeners when loading attributes from a model instance", function(){
+    spy = jasmine.createSpy();
+    var asset = new Asset({name: "test.pdf"});
+    var assetDupe = new Asset(asset.attributes());
+    asset.on('custom-event', spy);
+    assetDupe.on('some-other-event', spy);
+    asset.load(assetDupe);
+
+    asset.trigger('some-other-event');
+    expect(spy).not.toHaveBeenCalled();
+    asset.trigger('custom-event');
+    expect(spy).toHaveBeenCalled();
+  });
+
   it("attributes() respects getters/setters", function(){
     Asset.include({
       name: function(){


### PR DESCRIPTION
If you `load()` a model instance using a 2nd instance, and if the 2nd instance has any event callbacks,
all of the 1st instance's callbacks will be overwritten with those from the 2nd instance.

The fix is to ignore the `_callbacks` object when loading instance attributes.