### PR TITLE
Controller memory leak fix

### DIFF
--- a/lib/spine.js
+++ b/lib/spine.js
@@ -890,11 +890,9 @@ Released under the MIT License
 
     function Controller(options) {
       this.release = bind(this.release, this);
-      var context, key, parent_prototype, ref, value;
-      this.options = options;
-      ref = this.options;
-      for (key in ref) {
-        value = ref[key];
+      var context, key, parent_prototype, value;
+      for (key in options) {
+        value = options[key];
         this[key] = value;
       }
       if (!this.el) {

--- a/src/spine.coffee
+++ b/src/spine.coffee
@@ -507,10 +507,7 @@ class Controller extends Module
   tag: 'div'
 
   constructor: (options) ->
-    @options = options
-
-    for key, value of @options
-      @[key] = value
+    @[key] = value for key, value of options
 
     @el = document.createElement(@tag) unless @el
     @el = $(@el)


### PR DESCRIPTION
While doing some profiling, I noticed that `Controller` instances store a reference to the `options` object passed during instantiation. Then on the next line, the object is looped over to store it's values as instance attributes.

I'm not sure why `@options` is stored like this, but it means that any construction parameters are retained in memory for the life of the instance. So even if a controller replaces one of these instance attributes, the original construction attribute can't be garbage collected because the `@options` object is still referencing it...

The fix is really simple, but does anybody know if this would be a breaking change?
